### PR TITLE
Add Docker Build GitHub Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,9 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - docker
 
   workflow_dispatch:
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
   workflow_dispatch:
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - docker
 
 jobs:
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,6 @@ on:
       - main
       - docker
 
-  workflow_dispatch:
-
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -18,4 +16,6 @@ jobs:
         run: docker build -t ghcr.io/hyperledger-labs/firefly:latest .
 
       - name: Push
-        run: docker push ghcr.io/hyperledger-labs/firefly:latest
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker push ghcr.io/hyperledger-labs/firefly:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,13 @@
-name: Go
+name: Docker
 
 on:
   push:
     branches: [master]
 
+  workflow_dispatch:
+
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,17 @@
+name: Go
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: docker build -t ghcr.io/hyperledger-labs/firefly:latest .
+
+      - name: Push
+        run: docker push ghcr.io/hyperledger-labs/firefly:latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds a new GitHub Action that builds and pushes Docker images to GitHub Container Repository.

It also re-enables our normal PR checks after the repo was transferred.