### PR TITLE
Fix E2E test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -126,8 +126,9 @@ func TestEndToEnd(t *testing.T) {
 	}()
 
 	var resp *resty.Response
+	value := fftypes.Byteable("\"Hello\"")
 	data := fftypes.DataRefOrValue{
-		Value: fftypes.Byteable("\"Hello\""),
+		Value: value,
 	}
 
 	resp, err = BroadcastMessage(client1, &data)
@@ -135,8 +136,8 @@ func TestEndToEnd(t *testing.T) {
 	assert.Equal(t, 202, resp.StatusCode())
 
 	<-received1
-	validateReceivedMessages(t, client1, fftypes.Byteable("Hello"))
+	validateReceivedMessages(t, client1, value)
 
 	<-received2
-	validateReceivedMessages(t, client2, fftypes.Byteable("Hello"))
+	validateReceivedMessages(t, client2, value)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,11 +18,13 @@ package e2e
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/gorilla/websocket"
 	"github.com/hyperledger-labs/firefly/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,6 +42,27 @@ func pollForUp(t *testing.T, client *resty.Client) {
 	}
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode())
+}
+
+func validateReceivedMessages(t *testing.T, client *resty.Client, value fftypes.Byteable) {
+	resp, err := GetMessages(client)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode())
+
+	messages := resp.Result().(*[]fftypes.Message)
+	assert.Equal(t, 1, len(*messages))
+	assert.Equal(t, fftypes.LowerCasedType("batch_pin"), (*messages)[0].Header.TxType)
+	assert.Equal(t, "default", (*messages)[0].Header.Namespace)
+	assert.Equal(t, fftypes.FFNameArray{"default"}, (*messages)[0].Header.Topics)
+
+	resp, err = GetData(client)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode())
+
+	data := resp.Result().(*[]fftypes.Data)
+	assert.Equal(t, 1, len(*data))
+	assert.Equal(t, "default", (*data)[0].Namespace)
+	assert.Equal(t, value, (*data)[0].Value)
 }
 
 func TestEndToEnd(t *testing.T) {
@@ -63,25 +86,57 @@ func TestEndToEnd(t *testing.T) {
 	pollForUp(t, client1)
 	pollForUp(t, client2)
 
-	var resp *resty.Response
-	definitionName := "definition1"
+	wsUrl1 := url.URL{
+		Scheme:   "ws",
+		Host:     fmt.Sprintf("localhost:%d", port1),
+		Path:     "/ws",
+		RawQuery: "namespace=default&ephemeral&autoack",
+	}
+	wsUrl2 := url.URL{
+		Scheme:   "ws",
+		Host:     fmt.Sprintf("localhost:%d", port2),
+		Path:     "/ws",
+		RawQuery: "namespace=default&ephemeral&autoack",
+	}
 
-	resp, err = BroadcastDatatype(client1, definitionName)
+	t.Logf("Websocket 1: " + wsUrl1.String())
+	t.Logf("Websocket 2: " + wsUrl2.String())
+
+	ws1, _, err := websocket.DefaultDialer.Dial(wsUrl1.String(), nil)
+	require.NoError(t, err)
+	ws2, _, err := websocket.DefaultDialer.Dial(wsUrl2.String(), nil)
+	require.NoError(t, err)
+
+	received1 := make(chan bool)
+	go func() {
+		for {
+			_, _, err := ws1.ReadMessage()
+			require.NoError(t, err)
+			received1 <- true
+		}
+	}()
+
+	received2 := make(chan bool)
+	go func() {
+		for {
+			_, _, err := ws2.ReadMessage()
+			require.NoError(t, err)
+			received2 <- true
+		}
+	}()
+
+	var resp *resty.Response
+	data := fftypes.DataRefOrValue{
+		Value: fftypes.Byteable("\"Hello\""),
+	}
+
+	resp, err = BroadcastMessage(client1, &data)
 	require.NoError(t, err)
 	assert.Equal(t, 202, resp.StatusCode())
 
-	resp, err = GetData(client1)
-	require.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode())
-	data := resp.Result().(*[]fftypes.Data)
-	assert.Equal(t, 1, len(*data))
-	assert.Equal(t, "default", (*data)[0].Namespace)
-	assert.Equal(t, fftypes.ValidatorType("datadef"), (*data)[0].Validator)
-	assert.Equal(t, definitionName, (*data)[0].Value.JSONObject().GetString("name"))
+	<-received1
+	validateReceivedMessages(t, client1, fftypes.Byteable("Hello"))
 
-	resp, err = GetData(client2)
-	require.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode())
-	data = resp.Result().(*[]fftypes.Data)
-	t.Logf("Returned results from member 2: %d", len(*data))
+	<-received2
+	validateReceivedMessages(t, client2, fftypes.Byteable("Hello"))
 }

--- a/test/e2e/restclient.go
+++ b/test/e2e/restclient.go
@@ -22,9 +22,10 @@ import (
 )
 
 var (
-	urlGetNamespaces     = "/namespaces"
-	urlBroadcastDatatype = "/namespaces/default/broadcast/datatype"
-	urlGetData           = "/namespaces/default/data"
+	urlGetNamespaces    = "/namespaces"
+	urlGetMessages      = "/namespaces/default/messages"
+	urlBroadcastMessage = "/namespaces/default/broadcast/message"
+	urlGetData          = "/namespaces/default/data"
 )
 
 func GetNamespaces(client *resty.Client) (*resty.Response, error) {
@@ -33,37 +34,18 @@ func GetNamespaces(client *resty.Client) (*resty.Response, error) {
 		Get(urlGetNamespaces)
 }
 
-func BroadcastDatatype(client *resty.Client, name string) (*resty.Response, error) {
+func GetMessages(client *resty.Client) (*resty.Response, error) {
 	return client.R().
-		SetBody(fftypes.Datatype{
-			Name:    name,
-			Version: "1",
-			Value: fftypes.Byteable(`
-			{
-				"type": "object",
-				"properties": {
-					"property1": {
-						"type": "string"
-					}
-				}// Copyright © 2021 Kaleido, Inc.
-				//
-				// SPDX-License-Identifier: Apache-2.0
-				//
-				// Licensed under the Apache License, Version 2.0 (the "License");
-				// you may not use this file except in compliance with the License.
-				// You may obtain a copy of the License at
-				//
-				//     http://www.apache.org/licenses/LICENSE-2.0
-				//
-				// Unless required by applicable law or agreed to in writing, software
-				// distributed under the License is distributed on an "AS IS" BASIS,
-				// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-				// See the License for the specific language governing permissions and
-				// limitations under the License.
-				
-				
-			}`),
-		}).Post(urlBroadcastDatatype)
+		SetResult(&[]fftypes.Message{}).
+		Get(urlGetMessages)
+}
+
+func BroadcastMessage(client *resty.Client, data *fftypes.DataRefOrValue) (*resty.Response, error) {
+	return client.R().
+		SetBody(fftypes.MessageInput{
+			InputData: fftypes.InputData{data},
+		}).
+		Post(urlBroadcastMessage)
 }
 
 func GetData(client *resty.Client) (*resty.Response, error) {

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -2,12 +2,20 @@
 set -euo pipefail
 
 CWD=$(dirname "$0")
-CLI=ff
+CLI="ff -v --ansi never"
 STACK_DIR=~/.firefly/stacks
 STACK_NAME=firefly-e2e
 STACK_FILE=$STACK_DIR/$STACK_NAME/stack.json
 DOWNLOAD_CLI=true
 CREATE_STACK=true
+BUILD_FIREFLY=true
+
+cd $CWD
+
+if $BUILD_FIREFLY
+then
+	docker build -t kaleidoinc/firefly:latest ../..
+fi
 
 if $DOWNLOAD_CLI
 then
@@ -22,4 +30,4 @@ then
 fi
 
 export STACK_FILE
-cd $CWD && go test -v .
+go test -v .


### PR DESCRIPTION
This gets the E2E test running again with the latest API. Can (should) be run manually before commits with `./test/e2e/run.sh`. Eventually will get it added to a GitHub action as well.

It's not as clean or as thorough as it could be, but it's a start. Feedback/future suggestions welcome.