### PR TITLE
Add namespace to operation filter factory

### DIFF
--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -462,6 +462,7 @@ var OperationQueryFactory = &queryFields{
 	"tx":        &UUIDField{},
 	"type":      &StringField{},
 	"member":    &StringField{},
+	"namespace": &StringField{},
 	"status":    &StringField{},
 	"error":     &StringField{},
 	"plugin":    &StringField{},


### PR DESCRIPTION
` "error": "FF10148: Unknown filter 'namespace'"` when querying operations on API