### PR TITLE
Call Reset() before reading config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -287,6 +287,8 @@ func Reset() {
 
 // ReadConfig initializes the config
 func ReadConfig(cfgFile string) error {
+	Reset()
+
 	// Set precedence order for reading config location
 	viper.SetEnvPrefix("firefly")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))


### PR DESCRIPTION
Currently the code never applies the default values for config options, resulting in a lot of problems. This restores the previous behavior.