### PR TITLE
Call Reset() before reading config on startup

### DIFF
--- a/cmd/firefly.go
+++ b/cmd/firefly.go
@@ -90,6 +90,7 @@ func Execute() error {
 func run() error {
 
 	// Read the configuration
+	config.Reset()
 	err := config.ReadConfig(cfgFile)
 
 	// Setup logging after reading config (even if failed), to output header correctly


### PR DESCRIPTION
This should fix default values not getting applied at startup.