### PR TITLE
Add config options for ethconnect prefix

### DIFF
--- a/internal/blockchain/ethereum/config.go
+++ b/internal/blockchain/ethereum/config.go
@@ -24,6 +24,8 @@ import (
 const (
 	defaultBatchSize    = 50
 	defaultBatchTimeout = 500
+	defaultPrefixShort  = "fly"
+	defaultPrefixLong   = "firefly"
 )
 
 const (
@@ -41,6 +43,10 @@ const (
 	EthconnectConfigBatchTimeout = "batchTimeout"
 	// EthconnectConfigSkipEventstreamInit disables auto-configuration of event streams
 	EthconnectConfigSkipEventstreamInit = "skipEventstreamInit"
+	// EthconnectPrefixShort is used in the query string in requests to ethconnect
+	EthconnectPrefixShort = "prefixShort"
+	// EthconnectPrefixLong is used in HTTP headers in requests to ethconnect
+	EthconnectPrefixLong = "prefixLong"
 )
 
 func (e *Ethereum) InitPrefix(prefix config.Prefix) {
@@ -51,4 +57,6 @@ func (e *Ethereum) InitPrefix(prefix config.Prefix) {
 	ethconnectConf.AddKnownKey(EthconnectConfigSkipEventstreamInit)
 	ethconnectConf.AddKnownKey(EthconnectConfigBatchSize, defaultBatchSize)
 	ethconnectConf.AddKnownKey(EthconnectConfigBatchTimeout, defaultBatchTimeout)
+	ethconnectConf.AddKnownKey(EthconnectPrefixShort, defaultPrefixShort)
+	ethconnectConf.AddKnownKey(EthconnectPrefixLong, defaultPrefixLong)
 }

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -44,6 +44,8 @@ type Ethereum struct {
 	ctx          context.Context
 	topic        string
 	instancePath string
+	prefixShort  string
+	prefixLong   string
 	capabilities *blockchain.Capabilities
 	callbacks    blockchain.Callbacks
 	client       *resty.Client
@@ -122,6 +124,9 @@ func (e *Ethereum) Init(ctx context.Context, prefix config.Prefix, callbacks blo
 	if e.topic == "" {
 		return i18n.NewError(ctx, i18n.MsgMissingPluginConfig, "topic", "blockchain.ethconnect")
 	}
+
+	e.prefixShort = ethconnectConf.GetString(EthconnectPrefixShort)
+	e.prefixLong = ethconnectConf.GetString(EthconnectPrefixLong)
 
 	e.client = restclient.New(e.ctx, ethconnectConf)
 	e.capabilities = &blockchain.Capabilities{
@@ -461,8 +466,8 @@ func (e *Ethereum) SubmitBatchPin(ctx context.Context, ledgerID *fftypes.UUID, i
 	path := fmt.Sprintf("%s/pinBatch", e.instancePath)
 	res, err := e.client.R().
 		SetContext(ctx).
-		SetQueryParam("fly-from", identity.OnChain).
-		SetQueryParam("fly-sync", "false").
+		SetQueryParam(e.prefixShort+"-from", identity.OnChain).
+		SetQueryParam(e.prefixShort+"-sync", "false").
 		SetBody(input).
 		SetResult(tx).
 		Post(path)

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -314,6 +314,8 @@ func newTestEthereum() *Ethereum {
 		client:       resty.New().SetHostURL("http://localhost:12345"),
 		instancePath: "/instances/0x12345",
 		topic:        "topic1",
+		prefixShort:  defaultPrefixShort,
+		prefixLong:   defaultPrefixLong,
 	}
 }
 
@@ -339,8 +341,8 @@ func TestSubmitBatchPinOK(t *testing.T) {
 		func(req *http.Request) (*http.Response, error) {
 			var body map[string]interface{}
 			json.NewDecoder(req.Body).Decode(&body)
-			assert.Equal(t, addr, req.FormValue("fly-from"))
-			assert.Equal(t, "false", req.FormValue("fly-sync"))
+			assert.Equal(t, addr, req.FormValue(defaultPrefixShort+"-from"))
+			assert.Equal(t, "false", req.FormValue(defaultPrefixShort+"-sync"))
 			assert.Equal(t, "0x9ffc50ff6bfe4502adc793aea54cc059c5df767cfe444e038eb51c5523097db5", body["uuids"])
 			assert.Equal(t, ethHexFormatB32(batch.BatchHash), body["batchHash"])
 			assert.Equal(t, ethHexFormatB32(batch.BatchPaylodRef), body["payloadRef"])


### PR DESCRIPTION
This PR adds configuration options for the `ethconnect` plugin:

- `shortPrefix`: used in query parameters in requests to `ethconnect`
- `longPrefix`: used in x-headers in requests to `ethconnect` if headers are used in the future