### PR TITLE
Wait to reset parent context after HTTP request context finishes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6 // indirect
 	github.com/golangci/goconst v0.0.0-20180610141641-041c5f2b40f3 // indirect
 	github.com/golangci/gocyclo v0.0.0-20180528134321-2becd97e67ee // indirect
-	github.com/golangci/golangci-lint v1.41.0 // indirect
+	github.com/golangci/golangci-lint v1.41.1 // indirect
 	github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc // indirect
 	github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21 // indirect
 	github.com/google/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -360,6 +360,8 @@ github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a h1:iR3fYXUjHCR97qWS
 github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a/go.mod h1:9qCChq59u/eW8im404Q2WWTrnBUQKjpNYKMbU4M7EFU=
 github.com/golangci/golangci-lint v1.41.0 h1:1kfytWKEn2EPjniwD5xCwWtHAHR57q+vmDX3+VBoJac=
 github.com/golangci/golangci-lint v1.41.0/go.mod h1:30veY960fiZ7Lk2L3naBpz40K/AnztglOupwZVfcT1s=
+github.com/golangci/golangci-lint v1.41.1 h1:KH28pTSqRu6DTXIAANl1sPXNCmqg4VEH21z6G9Wj4SM=
+github.com/golangci/golangci-lint v1.41.1/go.mod h1:LPtcY3aAAU8wydHrKpnanx9Og8K/cblZSyGmI5CJZUk=
 github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc/go.mod h1:e5tpTHCfVze+7EpLEozzMB3eafxo2KT5veNg1k6byQU=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPzPD4Gpb/QgoRfSBR0jdhwGyAWwMSA=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
@@ -831,6 +833,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.2.1 h1:t1WWL0RGJJBo5KZ0u2c/FGY1QQgx2gUbHWzBmOKWs98=
 github.com/ryancurrah/gomodguard v1.2.1/go.mod h1:tpI+C/nzvfUR3bF28b5QHpTn/jM/zlGniI++6ZlIWeE=
+github.com/ryancurrah/gomodguard v1.2.2 h1:ZJQeYHZ2kaJpojoQBaGqpsn5g7GMcePY36uUGW1umbs=
+github.com/ryancurrah/gomodguard v1.2.2/go.mod h1:tpI+C/nzvfUR3bF28b5QHpTn/jM/zlGniI++6ZlIWeE=
 github.com/ryanrolds/sqlclosecheck v0.3.0 h1:AZx+Bixh8zdUBxUA1NxbxVAS78vTPq4rCb8OUZI9xFw=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -48,7 +48,11 @@ func (or *orchestrator) PutConfigRecord(ctx context.Context, key string, value f
 }
 
 func (or *orchestrator) ResetConfig(ctx context.Context) {
-	or.cancelCtx()
+	// Restart the current context finishes to pick up the configuration change
+	go func() {
+		<-ctx.Done()
+		or.cancelCtx()
+	}()
 }
 
 func (or *orchestrator) DeleteConfigRecord(ctx context.Context, key string) (err error) {

--- a/internal/orchestrator/config_test.go
+++ b/internal/orchestrator/config_test.go
@@ -92,6 +92,9 @@ func TestGetConfig(t *testing.T) {
 
 func TestResetConfig(t *testing.T) {
 	or := newTestOrchestrator()
-	or.ResetConfig(context.Background())
+	requestCtx, cancelFunc := context.WithCancel(context.Background())
+	or.ResetConfig(requestCtx)
+	// Simulates the HTTP completing
+	cancelFunc()
 	<-or.ctx.Done()
 }


### PR DESCRIPTION
This fixes HTTP requests sometimes failing when resetting FireFly after a config change.