### PR TITLE
Fix pending unpinned sends

### DIFF
--- a/internal/privatemessaging/message.go
+++ b/internal/privatemessaging/message.go
@@ -63,14 +63,14 @@ func (pm *privateMessaging) resolveAndSend(ctx context.Context, sender *fftypes.
 		return err
 	}
 
-	if in.Message.Header.TxType == fftypes.TransactionTypeNone {
-		in.Message.Confirmed = fftypes.Now()
-		in.Message.Pending = false
-	}
-
 	// Seal the message
 	if err := in.Message.Seal(ctx); err != nil {
 		return err
+	}
+
+	if in.Message.Header.TxType == fftypes.TransactionTypeNone {
+		in.Message.Confirmed = fftypes.Now()
+		in.Message.Pending = false
 	}
 
 	// Store the message - this asynchronously triggers the next step in process


### PR DESCRIPTION
Currently if you send an unpinned message, it is correctly marked `pending: false` (with a confirmed timestamp) on the receiving node(s), but the sending node leaves it forever in a `pending` state on the sender.
This means in the UI, all the requests are shown _before_ the replies 🙃 

The problem was the unpinned send code was setting `pending` and `confirmed` _before_ sealing the message, which then reset those back to default.

![image](https://user-images.githubusercontent.com/6660217/122996051-6345ff00-d378-11eb-91b2-19bd3d7c2e37.png)