### PR TITLE
Fix CSS on swagger docs

### DIFF
--- a/docs/swagger/swagger.md
+++ b/docs/swagger/swagger.md
@@ -13,6 +13,16 @@ Note: The 'Try it out' buttons will not work on this page, because it's not runn
 
 <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css">
 
+<style>
+code {
+    background-color: inherit;
+    border: inherit;
+}
+td, th {
+    background-color: inherit;
+}
+</style>
+
 <div id="swagger-ui"></div>
 
 <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-standalone-preset.js" charset="UTF-8"></script>


### PR DESCRIPTION
Previously the CSS for the Swagger UI was being overriden by the Jekyll theme. This made code blocks look like this:
<img width="497" src="https://user-images.githubusercontent.com/2530008/124167879-632db980-da72-11eb-9e80-40262ea194e2.png">

These changes fix the CSS so the Swagger theme is preserved and they now look like this:
<img width="497" alt="Screen Shot 2021-07-01 at 1 43 28 PM" src="https://user-images.githubusercontent.com/2530008/124167979-88bac300-da72-11eb-9234-3301c3706190.png">
