### PR TITLE
E2E Enhancements

### DIFF
--- a/internal/batch/batch_processor.go
+++ b/internal/batch/batch_processor.go
@@ -267,7 +267,7 @@ func (bp *batchProcessor) persistBatch(batch *fftypes.Batch, newWork []*batchWor
 					Type: fftypes.TransactionTypeBatchPin,
 					ID:   fftypes.NewUUID(),
 				}
-				contexts, err = bp.maskContexts(bp.ctx, batch)
+				contexts, err = bp.maskContexts(ctx, batch)
 				batch.Hash = batch.Payload.Hash()
 				log.L(ctx).Debugf("Batch %s sealed. Hash=%s", batch.ID, batch.Hash)
 			}

--- a/internal/database/sqlcommon/sqlcommon.go
+++ b/internal/database/sqlcommon/sqlcommon.go
@@ -131,7 +131,7 @@ func (s *SQLCommon) beginOrUseTx(ctx context.Context) (ctx1 context.Context, tx 
 	tx = &txWrapper{
 		sqlTX: sqlTX,
 	}
-	ctx1 = context.WithValue(ctx, txContextKey{}, tx)
+	ctx1 = context.WithValue(ctx1, txContextKey{}, tx)
 	l.Debugf("SQL<- begin")
 	return ctx1, tx, false, err
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -117,8 +117,8 @@ func beforeE2ETest(t *testing.T) *testState {
 	stack, err := ReadStack(stackFile)
 	assert.NoError(t, err)
 
-	var authHeader1 *http.Header
-	var authHeader2 *http.Header
+	var authHeader1 http.Header
+	var authHeader2 http.Header
 
 	ts := &testState{
 		t:         t,
@@ -145,7 +145,7 @@ func beforeE2ETest(t *testing.T) *testState {
 	if stack.Members[0].Username != "" && stack.Members[0].Password != "" {
 		t.Log("Setting auth for user 1")
 		ts.client1.SetBasicAuth(stack.Members[0].Username, stack.Members[0].Password)
-		authHeader1 = &http.Header{
+		authHeader1 = http.Header{
 			"Authorization": []string{fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", stack.Members[0].Username, stack.Members[0].Password))))},
 		}
 	}
@@ -153,7 +153,7 @@ func beforeE2ETest(t *testing.T) *testState {
 	if stack.Members[1].Username != "" && stack.Members[1].Password != "" {
 		t.Log("Setting auth for user 2")
 		ts.client2.SetBasicAuth(stack.Members[1].Username, stack.Members[1].Password)
-		authHeader2 = &http.Header{
+		authHeader2 = http.Header{
 			"Authorization": []string{fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", stack.Members[1].Username, stack.Members[1].Password))))},
 		}
 	}
@@ -191,13 +191,13 @@ func beforeE2ETest(t *testing.T) *testState {
 	t.Logf("Websocket 1: " + wsUrl1.String())
 	t.Logf("Websocket 2: " + wsUrl2.String())
 
-	ts.ws1, _, err = websocket.DefaultDialer.Dial(wsUrl1.String(), *authHeader1)
+	ts.ws1, _, err = websocket.DefaultDialer.Dial(wsUrl1.String(), authHeader1)
 	if err != nil {
 		t.Logf(err.Error())
 	}
 	require.NoError(t, err)
 
-	ts.ws2, _, err = websocket.DefaultDialer.Dial(wsUrl2.String(), *authHeader2)
+	ts.ws2, _, err = websocket.DefaultDialer.Dial(wsUrl2.String(), authHeader2)
 	require.NoError(t, err)
 
 	ts.done = func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"image/png"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -113,10 +114,11 @@ func beforeE2ETest(t *testing.T) *testState {
 		t.Fatal("STACK_FILE must be set")
 	}
 
-	port1, err := GetMemberPort(stackFile, 0)
-	require.NoError(t, err)
-	port2, err := GetMemberPort(stackFile, 1)
-	require.NoError(t, err)
+	stack, err := ReadStack(stackFile)
+	assert.NoError(t, err)
+
+	var authHeader1 *http.Header
+	var authHeader2 *http.Header
 
 	ts := &testState{
 		t:         t,
@@ -125,8 +127,36 @@ func beforeE2ETest(t *testing.T) *testState {
 		client2:   NewResty(t),
 	}
 
-	ts.client1.SetHostURL(fmt.Sprintf("http://localhost:%d/api/v1", port1))
-	ts.client2.SetHostURL(fmt.Sprintf("http://localhost:%d/api/v1", port2))
+	httpProtocolClient1 := "http"
+	websocketProtocolClient1 := "ws"
+	httpProtocolClient2 := "http"
+	websocketProtocolClient2 := "ws"
+	if stack.Members[0].UseHTTPS {
+		httpProtocolClient1 = "https"
+		websocketProtocolClient1 = "wss"
+	}
+	if stack.Members[1].UseHTTPS {
+		httpProtocolClient2 = "https"
+		websocketProtocolClient2 = "wss"
+	}
+	ts.client1.SetHostURL(fmt.Sprintf("%s://%s:%d/api/v1", httpProtocolClient1, stack.Members[0].FireflyHostname, stack.Members[0].ExposedFireflyPort))
+	ts.client2.SetHostURL(fmt.Sprintf("%s://%s:%d/api/v1", httpProtocolClient2, stack.Members[1].FireflyHostname, stack.Members[1].ExposedFireflyPort))
+
+	if stack.Members[0].Username != "" && stack.Members[0].Password != "" {
+		t.Log("Setting auth for user 1")
+		ts.client1.SetBasicAuth(stack.Members[0].Username, stack.Members[0].Password)
+		authHeader1 = &http.Header{
+			"Authorization": []string{fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", stack.Members[0].Username, stack.Members[0].Password))))},
+		}
+	}
+
+	if stack.Members[1].Username != "" && stack.Members[1].Password != "" {
+		t.Log("Setting auth for user 2")
+		ts.client2.SetBasicAuth(stack.Members[1].Username, stack.Members[1].Password)
+		authHeader2 = &http.Header{
+			"Authorization": []string{fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", stack.Members[1].Username, stack.Members[1].Password))))},
+		}
+	}
 
 	t.Logf("Client 1: " + ts.client1.HostURL)
 	t.Logf("Client 2: " + ts.client2.HostURL)
@@ -146,14 +176,14 @@ func beforeE2ETest(t *testing.T) *testState {
 	}
 
 	wsUrl1 := url.URL{
-		Scheme:   "ws",
-		Host:     fmt.Sprintf("localhost:%d", port1),
+		Scheme:   websocketProtocolClient1,
+		Host:     fmt.Sprintf("%s:%d", stack.Members[0].FireflyHostname, stack.Members[0].ExposedFireflyPort),
 		Path:     "/ws",
 		RawQuery: "namespace=default&ephemeral&autoack&filter.events=message_confirmed",
 	}
 	wsUrl2 := url.URL{
-		Scheme:   "ws",
-		Host:     fmt.Sprintf("localhost:%d", port2),
+		Scheme:   websocketProtocolClient2,
+		Host:     fmt.Sprintf("%s:%d", stack.Members[1].FireflyHostname, stack.Members[1].ExposedFireflyPort),
 		Path:     "/ws",
 		RawQuery: "namespace=default&ephemeral&autoack&filter.events=message_confirmed",
 	}
@@ -161,14 +191,19 @@ func beforeE2ETest(t *testing.T) *testState {
 	t.Logf("Websocket 1: " + wsUrl1.String())
 	t.Logf("Websocket 2: " + wsUrl2.String())
 
-	ts.ws1, _, err = websocket.DefaultDialer.Dial(wsUrl1.String(), nil)
+	ts.ws1, _, err = websocket.DefaultDialer.Dial(wsUrl1.String(), *authHeader1)
+	if err != nil {
+		t.Logf(err.Error())
+	}
 	require.NoError(t, err)
-	ts.ws2, _, err = websocket.DefaultDialer.Dial(wsUrl2.String(), nil)
+
+	ts.ws2, _, err = websocket.DefaultDialer.Dial(wsUrl2.String(), *authHeader2)
 	require.NoError(t, err)
 
 	ts.done = func() {
 		ts.ws1.Close()
 		ts.ws2.Close()
+		t.Log("WebSockets closed")
 	}
 	return ts
 }

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -12,13 +12,16 @@ if [ -z "${BUILD_FIREFLY}" ]; then
   BUILD_FIREFLY=true
 fi
 
+if [ -z "${STACK_FILE}" ]; then
+  STACK_FILE=$STACK_DIR/$STACK_NAME/stack.json
+fi
+
 set -euo pipefail
 
 CWD=$(dirname "$0")
 CLI="ff -v --ansi never"
 STACK_DIR=~/.firefly/stacks
 STACK_NAME=firefly-e2e
-STACK_FILE=$STACK_DIR/$STACK_NAME/stack.json
 
 cd $CWD
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -x
 
+set -eo pipefail
+
+CWD=$(dirname "$0")
+CLI="ff -v --ansi never"
+STACK_DIR=~/.firefly/stacks
+STACK_NAME=firefly-e2e
+
 if [ -z "${DOWNLOAD_CLI}" ]; then
   DOWNLOAD_CLI=true
 fi
@@ -16,12 +23,6 @@ if [ -z "${STACK_FILE}" ]; then
   STACK_FILE=$STACK_DIR/$STACK_NAME/stack.json
 fi
 
-set -euo pipefail
-
-CWD=$(dirname "$0")
-CLI="ff -v --ansi never"
-STACK_DIR=~/.firefly/stacks
-STACK_NAME=firefly-e2e
 
 cd $CWD
 

--- a/test/e2e/stack.go
+++ b/test/e2e/stack.go
@@ -26,7 +26,11 @@ type Stack struct {
 }
 
 type Member struct {
-	ExposedFireflyPort int `json:"exposedFireflyPort,omitempty"`
+	ExposedFireflyPort int    `json:"exposedFireflyPort,omitempty"`
+	FireflyHostname    string `json:"fireflyHostname,omitempty"`
+	Username           string `json:"username,omitempty"`
+	Password           string `json:"password,omitempty"`
+	UseHTTPS           bool   `json:"useHttps,omitempty"`
 }
 
 func GetMemberPort(filename string, n int) (int, error) {
@@ -42,4 +46,42 @@ func GetMemberPort(filename string, n int) (int, error) {
 	}
 
 	return stack.Members[n].ExposedFireflyPort, nil
+}
+
+func GetMemberHostname(filename string, n int) (string, error) {
+	jsonBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+
+	var stack Stack
+	err = json.Unmarshal(jsonBytes, &stack)
+	if err != nil {
+		return "", err
+	}
+
+	return stack.Members[n].FireflyHostname, nil
+}
+
+func ReadStack(filename string) (*Stack, error) {
+	jsonBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var stack *Stack
+	err = json.Unmarshal(jsonBytes, &stack)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply defaults, in case this stack.json is a local CLI environment
+	for _, member := range stack.Members {
+		if member.FireflyHostname == "" {
+			member.FireflyHostname = "127.0.0.1"
+		}
+
+	}
+
+	return stack, nil
 }


### PR DESCRIPTION
Resolves https://github.com/hyperledger-labs/firefly/issues/121

This PR adds the ability to run the E2E tests against any FireFly environment. If someone wants to run the tests against a remote FireFly (not on their local dev machine) they will need to create or modify a `stack.json` file to add some new fields that are not currently added by the CLI. These changes are still backwards compatible with existing `stack.json` files created by the CLI.

Here's an example of a new `stack.json` file that points to remote FireFly instances and also uses HTTPS and basic authentication.
```json
{
 "name": "dev",
 "members": [
  {
   "id": "0",
   "index": 0,
   "address": "0xac9c1260fb2ad017de65ce7cf68c0142903357ab",
   "privateKey": "0x02e9b8465ea1b585c2050b1fdf2fbe642c92b74192a0fb6f403ce2d91b5f5fdc",
   "exposedFireflyPort": 443,
   "exposedFireflyAdminPort": 5101,
   "exposedEthconnectPort": 5102,
   "exposedPostgresPort": 5104,
   "exposedDataexchangePort": 5105,
   "exposedIPFSApiPort": 5106,
   "exposedIPFSGWPort": 5107,
   "exposedUiPort ": 5103,
   "fireflyHostname": "zzglm93oa9-zzpl2jzg7u-firefly-os.dev2-ws.photic.io",
   "username": "username1",
   "password": "super-secret-password1",
   "useHttps": true
  },
  {
   "id": "1",
   "index": 1,
   "address": "0xd3ecae28b94b67c3b1651aa6c2efead818b3fca1",
   "privateKey": "0x49733950a87b2d78e6fd768057ccdcf7d957028f7b1fb50b405505d2495d11dd",
   "exposedFireflyPort": 443,
   "exposedFireflyAdminPort": 5201,
   "exposedEthconnectPort": 5202,
   "exposedPostgresPort": 5204,
   "exposedDataexchangePort": 5205,
   "exposedIPFSApiPort": 5206,
   "exposedIPFSGWPort": 5207,
   "exposedUiPort ": 5203,
   "fireflyHostname": "zzglm93oa9-zzmxfv7oo0-firefly-os.dev2-ws.photic.io",
   "username": "username2",
   "password": "super-secret-password2",
   "useHttps": true
  }
 ],
 "swarmKey": "/key/swarm/psk/1.0.0/\n/base16/\n1d699874aebc4e2f4f5ca66346f6e1048a9e5be639a60b374136a0c2b012f5f2",
 "exposedGanachePort": 5100
}
```


This PR also includes two other, unrelated fixes to database transaction contexts and logging. 