### PR TITLE
Latency optimize event delivery by default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,7 +270,7 @@ func Reset() {
 	viper.SetDefault(string(EventAggregatorRetryMaxDelay), "30s")
 	viper.SetDefault(string(EventAggregatorOpCorrelationRetries), 3)
 	viper.SetDefault(string(EventDispatcherBufferLength), 5)
-	viper.SetDefault(string(EventDispatcherBatchTimeout), "250ms")
+	viper.SetDefault(string(EventDispatcherBatchTimeout), "0")
 	viper.SetDefault(string(EventDispatcherPollTimeout), "30s")
 	viper.SetDefault(string(EventTransportsEnabled), []string{"websockets", "webhooks"})
 	viper.SetDefault(string(EventTransportsDefault), "websockets")

--- a/internal/events/event_poller.go
+++ b/internal/events/event_poller.go
@@ -257,7 +257,8 @@ func (ep *eventPoller) shoulderTap() {
 func (ep *eventPoller) waitForShoulderTapOrPollTimeout(lastEventCount int) bool {
 	l := log.L(ep.ctx)
 	longTimeoutDuration := ep.conf.eventPollTimeout
-	// We avoid a tight spin with the eventBatchingTimeout to allow messages to arrive
+	// For throughput optimized environments, we can set an eventBatchingTimeout to allow messages to arrive
+	// between polling cycles (at the cost of some dispatch latency)
 	if ep.conf.eventBatchTimeout > 0 && lastEventCount > 0 && lastEventCount < ep.conf.eventBatchSize {
 		shortTimeout := time.NewTimer(ep.conf.eventBatchTimeout)
 		select {


### PR DESCRIPTION
Early adopter feedback suggests that latency of event delivery is more important than throughput optimization, in the most common scenarios. Particularly in non-blockchain backed event scenarios, and even more in request/reply scenarios.

Currently we use a 250ms default latency on event delivery, to reduce pressure on the DB in high throughput scenarios by giving time for messages to arrive between queries.

This PR proposes making the default 0, optimizing for latency by default (before we cut the first release).