### PR TITLE
Rename topic field to topics

### DIFF
--- a/docs/gettingstarted/broadcast_data.md
+++ b/docs/gettingstarted/broadcast_data.md
@@ -67,7 +67,7 @@ Status: `202 Accepted` - the message is on it's way, but has not yet been confir
     "author": "0x0a65365587a65ce44938eab5a765fe8bc6532bdf", // set automatically in this example to the node org
     "created": "2021-07-01T18:06:24.5817016Z", // set automatically
     "namespace": "default", // the 'default' namespace was set in the URL
-    "topic": [
+    "topics": [
       "default" // the default topic that the message is published on, if no topic is set
     ],
     // datahash is calculated from the data array below
@@ -102,7 +102,7 @@ It is very good practice to set a `tag` and `topic` in each of your messages:
 {
   "header": {
     "tag": "new_widget_created",
-    "topic": ["widget_id_12345"]
+    "topics": ["widget_id_12345"]
   },
   "data": [
     {

--- a/docs/gettingstarted/private_send.md
+++ b/docs/gettingstarted/private_send.md
@@ -91,7 +91,7 @@ Status: `202 Accepted` - the message is on it's way, but has not yet been confir
     // The first time a group is used, the participant list is sent privately along with the
     // batch of messages in a `groupinit` message.
     "group": "2aa5297b5eed0c3a612a667c727ca38b54fb3b5cc245ebac4c2c7abe490bdf6c",
-    "topic": [
+    "topics": [
       "default" // the default topic that the message is published on, if no topic is set
     ],
     // datahash is calculated from the data array below
@@ -151,7 +151,7 @@ It is very good practice to set a `tag` and `topic` in each of your messages:
 {
   "header": {
     "tag": "new_widget_created",
-    "topic": [ "widget_id_12345" ]
+    "topics": ["widget_id_12345"]
   },
   "group": {
     "members": [{

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -55,7 +55,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array
@@ -387,7 +387,7 @@ paths:
                                     type: string
                                   tag:
                                     type: string
-                                  topic:
+                                  topics:
                                     items:
                                       type: string
                                     type: array
@@ -521,7 +521,7 @@ paths:
                                   type: string
                                 tag:
                                   type: string
-                                topic:
+                                topics:
                                   items:
                                     type: string
                                   type: array
@@ -619,7 +619,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array
@@ -732,7 +732,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array
@@ -1362,7 +1362,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array
@@ -1858,7 +1858,7 @@ paths:
                           type: string
                         tag:
                           type: string
-                        topic:
+                        topics:
                           items:
                             type: string
                           type: array
@@ -1973,7 +1973,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array
@@ -2611,7 +2611,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array
@@ -2738,7 +2738,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array
@@ -3849,7 +3849,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array
@@ -3917,7 +3917,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array
@@ -3997,7 +3997,7 @@ paths:
                         type: string
                       tag:
                         type: string
-                      topic:
+                      topics:
                         items:
                           type: string
                         type: array

--- a/pkg/fftypes/message.go
+++ b/pkg/fftypes/message.go
@@ -54,7 +54,7 @@ type MessageHeader struct {
 	Created   *FFTime         `json:"created,omitempty"`
 	Namespace string          `json:"namespace,omitempty"`
 	Group     *Bytes32        `json:"group,omitempty"`
-	Topics    FFNameArray     `json:"topic,omitempty"`
+	Topics    FFNameArray     `json:"topics,omitempty"`
 	Tag       string          `json:"tag,omitempty"`
 	DataHash  *Bytes32        `json:"datahash,omitempty"`
 }

--- a/pkg/fftypes/message_test.go
+++ b/pkg/fftypes/message_test.go
@@ -162,10 +162,10 @@ func TestSealKnownMessage(t *testing.T) {
 
 	// Header contains the data hash, and is hashed into the message hash
 	actualHeader, _ := json.Marshal(&msg.Header)
-	expectedHeader := `{"id":"2cd37805-5f40-4e12-962e-67868cde3049","cid":"39296b6e-91b9-4a61-b279-833c85b04d94","type":"private","txtype":"batch_pin","author":"0x12345","created":"2021-05-04T04:55:03.123456789Z","namespace":"ns1","group":"3fcc7e07069e441f07c9f6b26f16fcb2dc896222d72888675082fd308440d9ae","topic":["topic1","topic2"],"tag":"tag1","datahash":"2468d5c26cc85968acaf8b96d09476453916ea4eab41632a31d09efc7ab297d2"}`
+	expectedHeader := `{"id":"2cd37805-5f40-4e12-962e-67868cde3049","cid":"39296b6e-91b9-4a61-b279-833c85b04d94","type":"private","txtype":"batch_pin","author":"0x12345","created":"2021-05-04T04:55:03.123456789Z","namespace":"ns1","group":"3fcc7e07069e441f07c9f6b26f16fcb2dc896222d72888675082fd308440d9ae","topics":["topic1","topic2"],"tag":"tag1","datahash":"2468d5c26cc85968acaf8b96d09476453916ea4eab41632a31d09efc7ab297d2"}`
 	var msgHash Bytes32 = sha256.Sum256([]byte(expectedHeader))
 	assert.Equal(t, expectedHeader, string(actualHeader))
-	assert.Equal(t, `95f0a6a16ba67df7f24c5403733faebb89c304d66d55c21e149213d8ec7e2633`, msgHash.String())
+	assert.Equal(t, `b5b9da88ed83403754bf78ed596eab70b803fd02108635fb932c2416d9e379b7`, msgHash.String())
 	assert.Equal(t, msgHash, *msg.Hash)
 
 	// Verify also returns good


### PR DESCRIPTION
In a message header, previously there was a field named `topic` but it was of type `[]string`. It makes more sense to call this field `topics` because it is a list of several topic names. This PR changes this, but it is important to note that this is an API breaking change (though small in size).

Example message:

```json
{
  "header": {
    "tag": "new_widget_created",
    "topics": ["widget_id_12345"]
  },
  "data": [
    {
      "value": {
        "id": "widget_id_12345",
        "name": "superwidget"
      }
    }
  ]
}
```