### PR TITLE
Retry for errors on event poller startup, and only wait for ep close in one place

### DIFF
--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -88,9 +88,9 @@ func newAggregator(ctx context.Context, di database.Plugin, bm broadcast.Manager
 	return ag
 }
 
-func (ag *aggregator) start() error {
+func (ag *aggregator) start() {
 	go ag.offchainListener()
-	return ag.eventPoller.start()
+	ag.eventPoller.start()
 }
 
 func (ag *aggregator) offchainListener() {

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -345,8 +345,7 @@ func TestShutdownOnCancel(t *testing.T) {
 		Current:   12345,
 	}, nil)
 	mdi.On("GetPins", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Pin{}, nil)
-	err := ag.start()
-	assert.NoError(t, err)
+	ag.start()
 	assert.Equal(t, int64(12345), ag.eventPoller.pollingOffset)
 	ag.eventPoller.eventNotifier.newEvents <- 12345
 	cancel()

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -121,7 +121,7 @@ func NewEventManager(ctx context.Context, pi publicstorage.Plugin, di database.P
 func (em *eventManager) Start() (err error) {
 	err = em.subManager.start()
 	if err == nil {
-		err = em.aggregator.start()
+		em.aggregator.start()
 	}
 	return err
 }

--- a/internal/events/event_poller.go
+++ b/internal/events/event_poller.go
@@ -118,6 +118,7 @@ func (ep *eventPoller) start() {
 	})
 	if err != nil {
 		log.L(ep.ctx).Errorf("Event poller context closed before we successfully restored offset: %s", err)
+		close(ep.closed)
 		return
 	}
 	go ep.newEventNotifications()

--- a/internal/events/event_poller_test.go
+++ b/internal/events/event_poller_test.go
@@ -71,8 +71,7 @@ func TestStartStopEventPoller(t *testing.T) {
 		Current:   12345,
 	}, nil)
 	mdi.On("GetEvents", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Event{}, nil)
-	err := ep.start()
-	assert.NoError(t, err)
+	ep.start()
 	assert.Equal(t, int64(12345), ep.pollingOffset)
 	ep.eventNotifier.newEvents <- 12345
 	cancel()
@@ -160,10 +159,9 @@ func TestRestoreOffsetSpecific(t *testing.T) {
 func TestRestoreOffsetFailRead(t *testing.T) {
 	mdi := &databasemocks.Plugin{}
 	ep, cancel := newTestEventPoller(t, mdi, nil, nil)
-	defer cancel()
+	cancel() // to avoid infinite retry
 	mdi.On("GetOffset", mock.Anything, fftypes.OffsetTypeSubscription, "unit", "test").Return(nil, fmt.Errorf("pop"))
-	err := ep.start()
-	assert.EqualError(t, err, "pop")
+	ep.start()
 	mdi.AssertExpectations(t)
 }
 


### PR DESCRIPTION
Fix for https://github.com/hyperledger-labs/firefly/issues/134

Fixes two problems:
1. If we break out of the loop for leadership election before we start the event poller, then `close` will hang as it was waiting on `eventPoller.closed`.
  - No need for `ed.close` to wait on that, it can just wait on `ed.closed`
2. We were not handling errors from `eventPoller.start()`
  - Added retry for restoring the offset, and stopped it from returning an error in the case that the context is closed before it starts - it simply marks itself closed.