### PR TITLE
Allow multiple durable subscriptions to be started on a single websocket

### DIFF
--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -88,9 +88,9 @@ func newAggregator(ctx context.Context, di database.Plugin, bm broadcast.Manager
 	return ag
 }
 
-func (ag *aggregator) start() error {
+func (ag *aggregator) start() {
 	go ag.offchainListener()
-	return ag.eventPoller.start()
+	ag.eventPoller.start()
 }
 
 func (ag *aggregator) offchainListener() {

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -345,8 +345,7 @@ func TestShutdownOnCancel(t *testing.T) {
 		Current:   12345,
 	}, nil)
 	mdi.On("GetPins", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Pin{}, nil)
-	err := ag.start()
-	assert.NoError(t, err)
+	ag.start()
 	assert.Equal(t, int64(12345), ag.eventPoller.pollingOffset)
 	ag.eventPoller.eventNotifier.newEvents <- 12345
 	cancel()

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -121,7 +121,7 @@ func NewEventManager(ctx context.Context, pi publicstorage.Plugin, di database.P
 func (em *eventManager) Start() (err error) {
 	err = em.subManager.start()
 	if err == nil {
-		err = em.aggregator.start()
+		em.aggregator.start()
 	}
 	return err
 }

--- a/internal/events/event_poller.go
+++ b/internal/events/event_poller.go
@@ -118,6 +118,7 @@ func (ep *eventPoller) start() {
 	})
 	if err != nil {
 		log.L(ep.ctx).Errorf("Event poller context closed before we successfully restored offset: %s", err)
+		close(ep.closed)
 		return
 	}
 	go ep.newEventNotifications()

--- a/internal/events/event_poller_test.go
+++ b/internal/events/event_poller_test.go
@@ -71,8 +71,7 @@ func TestStartStopEventPoller(t *testing.T) {
 		Current:   12345,
 	}, nil)
 	mdi.On("GetEvents", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Event{}, nil)
-	err := ep.start()
-	assert.NoError(t, err)
+	ep.start()
 	assert.Equal(t, int64(12345), ep.pollingOffset)
 	ep.eventNotifier.newEvents <- 12345
 	cancel()
@@ -160,10 +159,9 @@ func TestRestoreOffsetSpecific(t *testing.T) {
 func TestRestoreOffsetFailRead(t *testing.T) {
 	mdi := &databasemocks.Plugin{}
 	ep, cancel := newTestEventPoller(t, mdi, nil, nil)
-	defer cancel()
+	cancel() // to avoid infinite retry
 	mdi.On("GetOffset", mock.Anything, fftypes.OffsetTypeSubscription, "unit", "test").Return(nil, fmt.Errorf("pop"))
-	err := ep.start()
-	assert.EqualError(t, err, "pop")
+	ep.start()
 	mdi.AssertExpectations(t)
 }
 

--- a/internal/events/websockets/websockets_test.go
+++ b/internal/events/websockets/websockets_test.go
@@ -329,7 +329,7 @@ func TestHandleAckWithAutoAck(t *testing.T) {
 	eventUUID := fftypes.NewUUID()
 	wsc := &websocketConnection{
 		ctx:          context.Background(),
-		startedCount: 1,
+		started:      []*websocketStartedSub{{ephemeral: false, name: "name1", namespace: "ns1"}},
 		sendMessages: make(chan interface{}, 1),
 		inflight: []*fftypes.EventDeliveryResponse{
 			{ID: eventUUID},
@@ -346,7 +346,7 @@ func TestHandleStartFlippingAutoAck(t *testing.T) {
 	eventUUID := fftypes.NewUUID()
 	wsc := &websocketConnection{
 		ctx:          context.Background(),
-		startedCount: 1,
+		started:      []*websocketStartedSub{{ephemeral: false, name: "name1", namespace: "ns1"}},
 		sendMessages: make(chan interface{}, 1),
 		inflight: []*fftypes.EventDeliveryResponse{
 			{ID: eventUUID},
@@ -365,7 +365,7 @@ func TestHandleStartWithChangeEvents(t *testing.T) {
 	wsc := &websocketConnection{
 		ctx:          context.Background(),
 		connID:       "conn1",
-		startedCount: 1,
+		started:      []*websocketStartedSub{{ephemeral: false, name: "name1", namespace: "ns1"}},
 		sendMessages: make(chan interface{}, 1),
 		ws: &WebSockets{
 			callbacks: mcb,
@@ -401,7 +401,7 @@ func TestHandleChangeEventsDispatchFail(t *testing.T) {
 	wsc := &websocketConnection{
 		ctx:          ctx,
 		connID:       "conn1",
-		startedCount: 1,
+		started:      []*websocketStartedSub{{ephemeral: false, name: "name1", namespace: "ns1"}},
 		sendMessages: make(chan interface{}), // wil block
 		ws: &WebSockets{
 			ctx:       ctx,
@@ -433,7 +433,7 @@ func TestHandleStartWithBadChangeEventsRegex(t *testing.T) {
 	wsc := &websocketConnection{
 		ctx:          context.Background(),
 		connID:       "conn1",
-		startedCount: 1,
+		started:      []*websocketStartedSub{{ephemeral: false, name: "name1", namespace: "ns1"}},
 		sendMessages: make(chan interface{}, 1),
 		inflight: []*fftypes.EventDeliveryResponse{
 			{ID: eventUUID},
@@ -462,8 +462,12 @@ func TestHandleStartWithBadChangeEventsRegex(t *testing.T) {
 func TestHandleAckMultipleStartedMissingSub(t *testing.T) {
 	eventUUID := fftypes.NewUUID()
 	wsc := &websocketConnection{
-		ctx:          context.Background(),
-		startedCount: 3,
+		ctx: context.Background(),
+		started: []*websocketStartedSub{
+			{ephemeral: false, name: "name1", namespace: "ns1"},
+			{ephemeral: false, name: "name2", namespace: "ns1"},
+			{ephemeral: false, name: "name3", namespace: "ns1"},
+		},
 		sendMessages: make(chan interface{}, 1),
 		inflight: []*fftypes.EventDeliveryResponse{
 			{ID: eventUUID},
@@ -486,7 +490,7 @@ func TestHandleAckMultipleStartedNoSubSingleMatch(t *testing.T) {
 			ctx:       context.Background(),
 			callbacks: cbs,
 		},
-		startedCount: 1,
+		started:      []*websocketStartedSub{{ephemeral: false, name: "name1", namespace: "ns1"}},
 		sendMessages: make(chan interface{}, 1),
 		inflight: []*fftypes.EventDeliveryResponse{
 			{ID: eventUUID},
@@ -587,7 +591,7 @@ func TestDispatchAutoAck(t *testing.T) {
 			callbacks:   cbs,
 			connections: make(map[string]*websocketConnection),
 		},
-		startedCount: 1,
+		started:      []*websocketStartedSub{{ephemeral: false, name: "name1", namespace: "ns1"}},
 		sendMessages: make(chan interface{}, 1),
 		autoAck:      true,
 	}


### PR DESCRIPTION
This made encountering #134 really likely for the app under test, as it was subscribing to one durable subscription, then immediately subscribing to another.
However, because the `webSocketsConnection` only allowed a single subscription in the matcher, that second subscribe was actually causing subscription manager to close the first subscription (as it no longer matched the connection).

Note in a PR chain with #135 (which is the fix for the deadlock in #134)