### PR TITLE
Emit events for locally produced unpinned private messages

### DIFF
--- a/docs/gettingstarted/private_send.md
+++ b/docs/gettingstarted/private_send.md
@@ -43,7 +43,7 @@ nav_order: 4
   - If the send is unpinned:
     - No data is written to the blockchain at all
     - The message is marked confirmed immediately
-    - The sender does **not** get a `message_confirmed` event
+      - The sender receives a `message_confirmed` event immediately
     - The other parties in the group get `message_confirmed` events as soon as the data arrives
 
 ## Additional info

--- a/internal/privatemessaging/message.go
+++ b/internal/privatemessaging/message.go
@@ -84,7 +84,14 @@ func (pm *privateMessaging) resolveAndSend(ctx context.Context, sender *fftypes.
 	}
 
 	if in.Message.Header.TxType == fftypes.TransactionTypeNone {
-		return pm.sendUnpinnedMessage(ctx, &in.Message)
+		err = pm.sendUnpinnedMessage(ctx, &in.Message)
+		if err != nil {
+			return err
+		}
+
+		// Emit a confirmation event locally immediately
+		event := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, in.Message.Header.Namespace, in.Message.Header.ID)
+		return pm.database.InsertEvent(ctx, event)
 	}
 
 	return nil


### PR DESCRIPTION
Currently we have a difference between unpinned and pinned private messaging:
- Pinned private messages emit a `message_confirmed` on _all_ members when the blockchain TX completes
- Unpinned messages emit a `message_confirmed` on all members _except_ the sender when they arrive
  - Originally it was thought this might be less confusing than emitting a message locally in the unpinned case.
  - We've found that it's actually more confusing. Particularly as it means that if you have a request/response messaging scenario via FireFly it changes the behavior of whether the locally connected apps get triggered or not.

With this PR in place, we become consistent.
- Pinned private messages emit a `message_confirmed` on _all_ members when the blockchain TX completes
- Unpinned messages emit a `message_confirmed` on _all_ members
  - Sender gets their event immediately
  - Other nodes get their events when the off-chain message arrives via DX
