### PR TITLE
Fix sequencing of submgr/webhooks and fix loop detection

### DIFF
--- a/internal/events/subscription_manager.go
+++ b/internal/events/subscription_manager.go
@@ -148,7 +148,11 @@ func (sm *subscriptionManager) start() error {
 			continue
 		}
 		sm.durableSubs[*subDef.ID] = newSub
+		for _, conn := range sm.connections {
+			sm.matchSubToConnLocked(conn, newSub)
+		}
 	}
+	log.L(sm.ctx).Infof("Subscription manager started - loaded %d durable subscriptions", len(sm.durableSubs))
 	go sm.subscriptionEventListener()
 	go sm.cel.changeEventListener()
 	return nil

--- a/internal/events/webhooks/webhooks.go
+++ b/internal/events/webhooks/webhooks.go
@@ -403,6 +403,11 @@ func (wh *WebHooks) DeliveryRequest(connID string, sub *fftypes.Subscription, ev
 		// avoid loops - and there's no way for us to detect here if a user has configured correctly
 		// to avoid a loop.
 		log.L(wh.ctx).Debugf("Webhook subscription with reply enabled called with reply event '%s'", event.ID)
+		wh.callbacks.DeliveryResponse(connID, &fftypes.EventDeliveryResponse{
+			ID:           event.ID,
+			Rejected:     false,
+			Subscription: event.Subscription,
+		})
 		return nil
 	}
 

--- a/internal/events/webhooks/webhooks_test.go
+++ b/internal/events/webhooks/webhooks_test.go
@@ -598,6 +598,11 @@ func TestDeliveryRequestReplyToReply(t *testing.T) {
 		},
 	}
 
+	mcb := wh.callbacks.(*eventsmocks.Callbacks)
+	mcb.On("DeliveryResponse", mock.Anything, mock.MatchedBy(func(response *fftypes.EventDeliveryResponse) bool {
+		return !response.Rejected // should be accepted as a no-op so we can move on to other events
+	}))
+
 	err := wh.DeliveryRequest(mock.Anything, sub, event, nil)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
- Fixes #115 - webhook subscriptions not working after restart
  - The problem here was that the submanager was initializing after Webhooks had registered the global connection, and the code was assuming no connections existed at the time submanager was starting. So it wasn't starting the dispatchers.
- Fixes an error where webhook message delivery stop functioning after the following error is logged:
  ```
  DEBUG Webhook subscription with reply enabled called with reply event '1cb8bc49-40e6-4496-bb96-620527d5eca9' pid=1
  ```
  - Here the problem was the loop detection code missing an ack on the event, so no further events were being delivered.