### PR TITLE
Fix dispatcher deadlock when using custom readahead

### DIFF
--- a/internal/events/event_dispatcher.go
+++ b/internal/events/event_dispatcher.go
@@ -63,6 +63,9 @@ type eventDispatcher struct {
 func newEventDispatcher(ctx context.Context, ei events.Plugin, di database.Plugin, dm data.Manager, rs *replySender, connID string, sub *subscription, en *eventNotifier, cel *changeEventListener) *eventDispatcher {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	readAhead := int(config.GetUint(config.SubscriptionDefaultsReadAhead))
+	if sub.definition.Options.ReadAhead != nil {
+		readAhead = int(*sub.definition.Options.ReadAhead)
+	}
 	ed := &eventDispatcher{
 		ctx: log.WithLogField(log.WithLogField(ctx,
 			"role", fmt.Sprintf("ed[%s]", connID)),
@@ -105,9 +108,6 @@ func newEventDispatcher(ctx context.Context, ei events.Plugin, di database.Plugi
 		newEventsHandler: ed.bufferedDelivery,
 		ephemeral:        sub.definition.Ephemeral,
 		firstEvent:       sub.definition.Options.FirstEvent,
-	}
-	if sub.definition.Options.ReadAhead != nil {
-		ed.readAhead = int(*sub.definition.Options.ReadAhead)
 	}
 
 	ed.eventPoller = newEventPoller(ctx, di, en, pollerConf)
@@ -273,8 +273,8 @@ func (ed *eventDispatcher) bufferedDelivery(events []fftypes.LocallySequenced) (
 		}
 		ed.mux.Unlock()
 
-		l.Debugf("Dispatcher event state: candidates=%d matched=%d inflight=%d queued=%d dispatched=%d dispatchable=%d lastAck=%d nacks=%d highest=%d",
-			len(candidates), matchCount, inflightCount, len(matching), dispatched, len(disapatchable), lastAck, nacks, highestOffset)
+		l.Debugf("Dispatcher event state: readahead=%d candidates=%d matched=%d inflight=%d queued=%d dispatched=%d dispatchable=%d lastAck=%d nacks=%d highest=%d",
+			ed.readAhead, len(candidates), matchCount, inflightCount, len(matching), dispatched, len(disapatchable), lastAck, nacks, highestOffset)
 
 		for _, event := range disapatchable {
 			ed.mux.Lock()

--- a/internal/events/event_dispatcher.go
+++ b/internal/events/event_dispatcher.go
@@ -63,6 +63,7 @@ type eventDispatcher struct {
 func newEventDispatcher(ctx context.Context, ei events.Plugin, di database.Plugin, dm data.Manager, rs *replySender, connID string, sub *subscription, en *eventNotifier, cel *changeEventListener) *eventDispatcher {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	readAhead := int(config.GetUint(config.SubscriptionDefaultsReadAhead))
+	buffLen := config.GetInt(config.EventDispatcherBufferLength)
 	ed := &eventDispatcher{
 		ctx: log.WithLogField(log.WithLogField(ctx,
 			"role", fmt.Sprintf("ed[%s]", connID)),
@@ -76,7 +77,7 @@ func newEventDispatcher(ctx context.Context, ei events.Plugin, di database.Plugi
 		subscription:  sub,
 		namespace:     sub.definition.Namespace,
 		inflight:      make(map[fftypes.UUID]*fftypes.Event),
-		eventDelivery: make(chan *fftypes.EventDelivery, readAhead+1),
+		eventDelivery: make(chan *fftypes.EventDelivery, buffLen),
 		changeEvents:  make(chan *fftypes.ChangeEvent),
 		readAhead:     readAhead,
 		acksNacks:     make(chan ackNack),
@@ -85,7 +86,7 @@ func newEventDispatcher(ctx context.Context, ei events.Plugin, di database.Plugi
 	}
 
 	pollerConf := &eventPollerConf{
-		eventBatchSize:             config.GetInt(config.EventDispatcherBufferLength),
+		eventBatchSize:             buffLen,
 		eventBatchTimeout:          config.GetDuration(config.EventDispatcherBatchTimeout),
 		eventPollTimeout:           config.GetDuration(config.EventDispatcherPollTimeout),
 		startupOffsetRetryAttempts: 0, // We need to keep trying to start indefinitely


### PR DESCRIPTION
Encountered the below deadlock with a zero readahead connection, where we can see:
- The `eventLoop` routine is waiting in `bufferedDelivery` to push message 2 of 3 into `eventDelivery` channel
- The `deliverEvents` routine is stuck in `deliveryResponse` trying to notify the the `eventLoop`

The architecture is intended to avoid this deadlock, by having a channel big enough that the `eventLoop` can always get all `dispatchable` events into it.

In the logs before the hang, I can see `matched=3` `dispatchable=3`.
This _should_ indicate that the readahead is at least 2, which means the channel should have 3 slots in it.

```
[2021-07-19T18:29:04.086Z] DEBUG Dispatcher event state: candidates=3 matched=3 inflight=0 queued=0 dispatched=0 dispatchable=3 lastAck=0 nacks=0 highest=25 pid=1 role=ed[pTv5Nky2] sub=ac36320d-55d9-479e-abb1-82c7d04cf720/default:ac36320d-55d9-47...
```

The problem is this line that tweaks the readAhead is after we created the channel:
```
	if sub.definition.Options.ReadAhead != nil {
		ed.readAhead = int(*sub.definition.Options.ReadAhead)
	}
```

This is true for the system events subscription (used for request/reply correlation) which defaults to 50:
https://github.com/hyperledger-labs/firefly/blob/526b45577f2eb6a501edec3ed833029df457109e/internal/events/system/events.go#L54

### Deadlock threads

```
goroutine 639 [select, 39 minutes]:
github.com/hyperledger-labs/firefly/internal/events.(*eventDispatcher).deliveryResponse(0xc0000a3520, 0xc000513770)
	/firefly/internal/events/event_dispatcher.go:425 +0x45a
github.com/hyperledger-labs/firefly/internal/events.(*subscriptionManager).deliveryResponse(0xc0000b7ea0, 0xe8c3b8, 0x12cdfc0, 0xc000337888, 0x8, 0xc000513770)
	/firefly/internal/events/subscription_manager.go:471 +0x125
github.com/hyperledger-labs/firefly/internal/events.(*boundCallbacks).DeliveryResponse(0xc00038c7b0, 0xc000337888, 0x8, 0xc000513770)
	/firefly/internal/events/bound_events_callbacks.go:38 +0x5e
github.com/hyperledger-labs/firefly/internal/events/system.(*Events).DeliveryRequest(0x12cdfc0, 0xc000337888, 0x8, 0xc0000a2f70, 0xc0001f63f0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/firefly/internal/events/system/events.go:104 +0x25f
github.com/hyperledger-labs/firefly/internal/events.(*eventDispatcher).deliverEvents(0xc0000a3520)
	/firefly/internal/events/event_dispatcher.go:380 +0x4de
created by github.com/hyperledger-labs/firefly/internal/events.(*eventDispatcher).electAndStart
	/firefly/internal/events/event_dispatcher.go:139 +0x273
```

```
goroutine 638 [chan send, 39 minutes]:
github.com/hyperledger-labs/firefly/internal/events.(*eventDispatcher).bufferedDelivery(0xc0000a3520, 0xc000447170, 0x3, 0x3, 0x0, 0x16, 0xe8d8d0)
	/firefly/internal/events/event_dispatcher.go:286 +0x17a
github.com/hyperledger-labs/firefly/internal/events.(*eventPoller).dispatchEventsRetry.func1(0x1, 0x0, 0xc0001d5938, 0x0)
	/firefly/internal/events/event_poller.go:224 +0x54
github.com/hyperledger-labs/firefly/internal/retry.(*Retry).Do(0xc000620348, 0xe87d60, 0xc000319f50, 0xd7d599, 0xe, 0xc000635f08, 0x0, 0xc000447170)
	/firefly/internal/retry/retry.go:55 +0xad
github.com/hyperledger-labs/firefly/internal/events.(*eventPoller).dispatchEventsRetry(0xc0003a7d40, 0xc000447170, 0x3, 0x3, 0x0, 0x0, 0x0)
	/firefly/internal/events/event_poller.go:223 +0xce
github.com/hyperledger-labs/firefly/internal/events.(*eventPoller).eventLoop(0xc0003a7d40)
	/firefly/internal/events/event_poller.go:206 +0x15b
created by github.com/hyperledger-labs/firefly/internal/events.(*eventPoller).start
	/firefly/internal/events/event_poller.go:123 +0x1a5
```