### PR TITLE
Avoid writing pins that can never be resolved

### DIFF
--- a/internal/database/sqlcommon/group_sql.go
+++ b/internal/database/sqlcommon/group_sql.go
@@ -119,7 +119,7 @@ func (s *SQLCommon) updateMembers(ctx context.Context, tx *txWrapper, group *fft
 					sq.Eq{"group_hash": group.Hash},
 				}),
 			nil, // no db change event for this sub update
-		); err != nil {
+		); err != nil && err != database.DeleteRecordNotFound {
 			return err
 		}
 	}

--- a/internal/database/sqlcommon/message_sql.go
+++ b/internal/database/sqlcommon/message_sql.go
@@ -176,7 +176,7 @@ func (s *SQLCommon) updateMessageDataRefs(ctx context.Context, tx *txWrapper, me
 					sq.Eq{"message_id": message.Header.ID},
 				}),
 			nil, // no change event
-		); err != nil {
+		); err != nil && err != database.DeleteRecordNotFound {
 			return err
 		}
 	}

--- a/internal/events/batch_pin_complete.go
+++ b/internal/events/batch_pin_complete.go
@@ -54,8 +54,8 @@ func (em *eventManager) handlePrivatePinComplete(batchPin *blockchain.BatchPin, 
 		// We process the batch into the DB as a single transaction (if transactions are supported), both for
 		// efficiency and to minimize the chance of duplicates (although at-least-once delivery is the core model)
 		err := em.database.RunAsGroup(em.ctx, func(ctx context.Context) error {
-			err := em.persistBatchTransaction(ctx, batchPin, signingIdentity, protocolTxID, additionalInfo)
-			if err == nil {
+			valid, err := em.persistBatchTransaction(ctx, batchPin, signingIdentity, protocolTxID, additionalInfo)
+			if valid && err == nil {
 				err = em.persistContexts(ctx, batchPin, true)
 			}
 			return err
@@ -64,15 +64,15 @@ func (em *eventManager) handlePrivatePinComplete(batchPin *blockchain.BatchPin, 
 	})
 }
 
-func (em *eventManager) persistBatchTransaction(ctx context.Context, batchPin *blockchain.BatchPin, signingIdentity string, protocolTxID string, additionalInfo fftypes.JSONObject) error {
+func (em *eventManager) persistBatchTransaction(ctx context.Context, batchPin *blockchain.BatchPin, signingIdentity string, protocolTxID string, additionalInfo fftypes.JSONObject) (valid bool, err error) {
 	// Get any existing record for the batch transaction record
 	tx, err := em.database.GetTransactionByID(ctx, batchPin.TransactionID)
 	if err != nil {
-		return err // a peristence failure here is considered retryable (so returned)
+		return false, err // a peristence failure here is considered retryable (so returned)
 	}
 	if err := fftypes.ValidateFFNameField(ctx, batchPin.Namespace, "namespace"); err != nil {
 		log.L(ctx).Errorf("Invalid batch '%s'. Transaction '%s' invalid namespace '%s': %a", batchPin.BatchID, batchPin.TransactionID, batchPin.Namespace, err)
-		return nil // This is not retryable. skip this batch
+		return false, nil // This is not retryable. skip this batch
 	}
 	if tx == nil {
 		// We're the first to write the transaction record on this node
@@ -93,7 +93,7 @@ func (em *eventManager) persistBatchTransaction(ctx context.Context, batchPin *b
 		*tx.Subject.Reference != *batchPin.BatchID ||
 		tx.Subject.Namespace != batchPin.Namespace {
 		log.L(ctx).Errorf("Invalid batch '%s'. Existing transaction '%s' does not match batch subject", batchPin.BatchID, tx.ID)
-		return nil // This is not retryable. skip this batch
+		return false, nil // This is not retryable. skip this batch
 	}
 
 	// Set the updates on the transaction
@@ -106,13 +106,13 @@ func (em *eventManager) persistBatchTransaction(ctx context.Context, batchPin *b
 	if err != nil {
 		if err == database.HashMismatch {
 			log.L(ctx).Errorf("Invalid batch '%s'. Transaction '%s' hash mismatch with existing record", batchPin.BatchID, tx.Hash)
-			return nil // This is not retryable. skip this batch
+			return false, nil // This is not retryable. skip this batch
 		}
 		log.L(ctx).Errorf("Failed to insert transaction for batch '%s': %s", batchPin.BatchID, err)
-		return err // a peristence failure here is considered retryable (so returned)
+		return false, err // a peristence failure here is considered retryable (so returned)
 	}
 
-	return nil
+	return true, nil
 }
 
 func (em *eventManager) persistContexts(ctx context.Context, batchPin *blockchain.BatchPin, private bool) error {
@@ -156,12 +156,11 @@ func (em *eventManager) handleBroadcastPinComplete(batchPin *blockchain.BatchPin
 		// We process the batch into the DB as a single transaction (if transactions are supported), both for
 		// efficiency and to minimize the chance of duplicates (although at-least-once delivery is the core model)
 		err := em.database.RunAsGroup(em.ctx, func(ctx context.Context) error {
-			err := em.persistBatchTransaction(ctx, batchPin, signingIdentity, protocolTxID, additionalInfo)
-			if err == nil {
-				var valid bool
+			valid, err := em.persistBatchTransaction(ctx, batchPin, signingIdentity, protocolTxID, additionalInfo)
+			// Note that in the case of a bad batch broadcast, we don't store the pin. Because we know we
+			// are never going to be able to process it (we retrieved it successfully, it's just invalid).
+			if valid && err == nil {
 				valid, err = em.persistBatchFromBroadcast(ctx, batch, batchPin.BatchHash, signingIdentity)
-				// Note that in the case of a bad batch broadcast, we don't store the pin. Because we know we
-				// are never going to be able to process it (we retrieved it successfully, it's just invalid).
 				if valid && err == nil {
 					err = em.persistContexts(ctx, batchPin, false)
 				}

--- a/internal/events/batch_pin_complete.go
+++ b/internal/events/batch_pin_complete.go
@@ -158,8 +158,11 @@ func (em *eventManager) handleBroadcastPinComplete(batchPin *blockchain.BatchPin
 		err := em.database.RunAsGroup(em.ctx, func(ctx context.Context) error {
 			err := em.persistBatchTransaction(ctx, batchPin, signingIdentity, protocolTxID, additionalInfo)
 			if err == nil {
-				err = em.persistBatchFromBroadcast(ctx, batch, batchPin.BatchHash, signingIdentity)
-				if err == nil {
+				var valid bool
+				valid, err = em.persistBatchFromBroadcast(ctx, batch, batchPin.BatchHash, signingIdentity)
+				// Note that in the case of a bad batch broadcast, we don't store the pin. Because we know we
+				// are never going to be able to process it (we retrieved it successfully, it's just invalid).
+				if valid && err == nil {
 					err = em.persistContexts(ctx, batchPin, false)
 				}
 			}

--- a/internal/events/batch_pin_complete_test.go
+++ b/internal/events/batch_pin_complete_test.go
@@ -343,8 +343,9 @@ func TestPersistBatchGetTransactionBadNamespace(t *testing.T) {
 	mdi := em.database.(*databasemocks.Plugin)
 	mdi.On("GetTransactionByID", mock.Anything, mock.Anything).Return(nil, nil)
 
-	err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
+	valid, err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
 	assert.NoError(t, err)
+	assert.False(t, valid)
 	mdi.AssertExpectations(t)
 }
 
@@ -363,8 +364,9 @@ func TestPersistBatchGetTransactionFail(t *testing.T) {
 	mdi := em.database.(*databasemocks.Plugin)
 	mdi.On("GetTransactionByID", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop"))
 
-	err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
+	valid, err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
 	assert.EqualError(t, err, "pop")
+	assert.False(t, valid)
 	mdi.AssertExpectations(t)
 }
 
@@ -385,8 +387,9 @@ func TestPersistBatchGetTransactionInvalidMatch(t *testing.T) {
 		ID: fftypes.NewUUID(), // wrong
 	}, nil)
 
-	err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
+	valid, err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
 	assert.NoError(t, err)
+	assert.False(t, valid)
 	mdi.AssertExpectations(t)
 }
 
@@ -406,8 +409,9 @@ func TestPersistBatcNewTXUpsertFail(t *testing.T) {
 	mdi.On("GetTransactionByID", mock.Anything, mock.Anything).Return(nil, nil)
 	mdi.On("UpsertTransaction", mock.Anything, mock.Anything, true, false).Return(fmt.Errorf("pop"))
 
-	err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
+	valid, err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
 	assert.EqualError(t, err, "pop")
+	assert.False(t, valid)
 	mdi.AssertExpectations(t)
 }
 
@@ -434,8 +438,9 @@ func TestPersistBatcExistingTXHashMismatch(t *testing.T) {
 	}, nil)
 	mdi.On("UpsertTransaction", mock.Anything, mock.Anything, true, false).Return(database.HashMismatch)
 
-	err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
+	valid, err := em.persistBatchTransaction(context.Background(), batchPin, "0x12345", "txid1", fftypes.JSONObject{})
 	assert.NoError(t, err)
+	assert.False(t, valid)
 	mdi.AssertExpectations(t)
 }
 

--- a/pkg/fftypes/jsondata.go
+++ b/pkg/fftypes/jsondata.go
@@ -75,6 +75,8 @@ func (jd JSONObject) GetStringOk(key string) (string, bool) {
 		return strconv.FormatBool(vt), true
 	case float64:
 		return strconv.FormatFloat(vt, 'f', -1, 64), true
+	case nil:
+		return "", false // no need to log for nil
 	default:
 		log.L(context.Background()).Errorf("Invalid string value '%+v' for key '%s'", vInterface, key)
 		return "", false

--- a/pkg/fftypes/jsondata_test.go
+++ b/pkg/fftypes/jsondata_test.go
@@ -75,6 +75,10 @@ func TestJSONObject(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "12345", v)
 
+	v, ok = JSONObject{}.GetStringOk("test")
+	assert.False(t, ok)
+	assert.Equal(t, "", v)
+
 	v, ok = JSONObject{"test": map[string]int{"x": 12345}}.GetStringOk("test")
 	assert.False(t, ok)
 	assert.Equal(t, "", v)


### PR DESCRIPTION
We saw a situation where broadcasts were not being processed by a network, and the reason logged was:
```
[2021-07-21T13:29:22.474Z] DEBUG Message 29ef8ae6-06a0-461c-b9d1-fa754e6f3315 pinned at sequence 11775 blocked by earlier context f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d at sequence 10667 dbtx=oWj1wBCU pid=1 role=aggregator
```

This was in a FireFly environment where it had been rebuilt, with fresh FireFly databases, but using the same on-chain contract. The context of the batches that could not be processed were organizataion definitions.

Inspecting the `pins` database table, we could see a list of un-dispatched pins for the same context (e.g. the same on-chain organization ID):
```
  seq  | masked |                               hash                               |               batch_id               | idx | dispatched |       created       
-------+--------+------------------------------------------------------------------+--------------------------------------+-----+------------+---------------------
     7 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | 43b86d42-63de-40af-aa5b-389577cbff0a |   0 | f          | 1626873947548837682
    10 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | 9f4f148d-0e9b-4cc9-80f1-1eb2dd7d7549 |   0 | f          | 1626873947701026182
    11 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | 16c95a7b-5459-4d33-93b5-4e9ffb7a037f |   0 | f          | 1626873947813108703
    17 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | 041ef318-713d-49f1-9837-6a0c8f7a7d03 |   0 | f          | 1626873948148579427
    18 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | adb54417-ab2f-4545-88d4-3bdaa85902a8 |   0 | f          | 1626873979795296873
    30 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | d8fec3c5-98d3-4fb6-96b8-5008471b5a06 |   0 | f          | 1626873980089044029
    31 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | d8fec3c5-98d3-4fb6-96b8-5008471b5a06 |   1 | f          | 1626873980092709323
  1275 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | b2e5cf70-748c-43db-bf53-8ffd2617be6c |   0 | f          | 1626873997040283520
  1276 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | d29e6e92-1897-4c98-af44-3a93143e754a |   0 | f          | 1626873997091277560
 10666 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | 4de72a48-abff-46e7-bf6c-86b4bcbe45f0 |   0 | f          | 1626874141923359231
 10667 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | 7a442e04-5c81-4d7f-a562-4b76c81ff106 |   0 | f          | 1626874141990760266
 11775 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | 8fc90cde-1a2d-4d11-895f-cae1ee828a12 |   0 | f          | 1626874162367960540
 11776 | f      | f80c0fb74bf21261afe26836caeb7fa4569580b5ba07f2cf35f4a645d000769d | ef5a83f8-b99a-4ee3-a98d-4390a8dd4db4 |   0 | f          | 1626874162428103422
```

The batch was **not** stored in the `batches` table, but looking in the `transactions` table where `ref` is the batch, we could see that the blockchain transaction had a `payloadRef` to IPFS that could be resolved.

From this we could work out that the problem is the batches were rejected **without being stored** ~surmising this is because the authors were not known, because they were from a previous chain where the organizations got defined in a different order to the current FireFly environment.~ - after further code inspection we do not verify the organization exists at this point. Rather just that the author identity can be resolved. However, the fact the batch is missing, but the pin is there was conclusive in the investigation.

The problem here is that we knew at the point we inserted the pin, it could never be resolved!!! ... so we shouldn't have inserted the pin at all. We should only have un-dispatched pins for cases where we are _waiting_ for data.