### PR TITLE
Fix E2E tests with more than 3 members

### DIFF
--- a/test/e2e/restclient.go
+++ b/test/e2e/restclient.go
@@ -110,6 +110,7 @@ func GetBlob(t *testing.T, client *resty.Client, data *fftypes.Data, expectedSta
 func GetOrgs(t *testing.T, client *resty.Client, expectedStatus int) (orgs []*fftypes.Organization) {
 	path := urlGetOrganizations
 	resp, err := client.R().
+		SetQueryParam("sort", "created").
 		SetResult(&orgs).
 		Get(path)
 	require.NoError(t, err)


### PR DESCRIPTION
The E2E tests expect members to be listed in the same order as they appear in the `stack.json` file. This change queries the API, asking it to sort the members in the expected order.