### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # FireFly Core Maintainers
-* peterbroadhurst nguyer awrichar
+* @peterbroadhurst @nguyer @awrichar
 
 # FireFly Documentation Maintainers
-/docs nickgaski
+/docs @nickgaski


### PR DESCRIPTION
I was missing the `@` characters on the GitHub IDs previously :(