### PR TITLE
Remove retry for correlating transactions

### DIFF
--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -369,13 +369,12 @@ func TestSubmitBatchPinOK(t *testing.T) {
 			assert.Equal(t, "0x9ffc50ff6bfe4502adc793aea54cc059c5df767cfe444e038eb51c5523097db5", body["uuids"])
 			assert.Equal(t, ethHexFormatB32(batch.BatchHash), body["batchHash"])
 			assert.Equal(t, "Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD", body["payloadRef"])
-			return httpmock.NewJsonResponderOrPanic(200, asyncTXSubmission{ID: "abcd1234"})(req)
+			return httpmock.NewJsonResponderOrPanic(200, asyncTXSubmission{})(req)
 		})
 
-	txid, err := e.SubmitBatchPin(context.Background(), nil, &fftypes.Identity{OnChain: addr}, batch)
+	err := e.SubmitBatchPin(context.Background(), nil, &fftypes.Identity{OnChain: addr}, batch)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "abcd1234", txid)
 
 }
 
@@ -406,13 +405,12 @@ func TestSubmitBatchEmptyPayloadRef(t *testing.T) {
 			assert.Equal(t, "0x9ffc50ff6bfe4502adc793aea54cc059c5df767cfe444e038eb51c5523097db5", body["uuids"])
 			assert.Equal(t, ethHexFormatB32(batch.BatchHash), body["batchHash"])
 			assert.Equal(t, "", body["payloadRef"])
-			return httpmock.NewJsonResponderOrPanic(200, asyncTXSubmission{ID: "abcd1234"})(req)
+			return httpmock.NewJsonResponderOrPanic(200, asyncTXSubmission{})(req)
 		})
 
-	txid, err := e.SubmitBatchPin(context.Background(), nil, &fftypes.Identity{OnChain: addr}, batch)
+	err := e.SubmitBatchPin(context.Background(), nil, &fftypes.Identity{OnChain: addr}, batch)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "abcd1234", txid)
 
 }
 
@@ -438,7 +436,7 @@ func TestSubmitBatchPinFail(t *testing.T) {
 	httpmock.RegisterResponder("POST", `http://localhost:12345/instances/0x12345/pinBatch`,
 		httpmock.NewStringResponder(500, "pop"))
 
-	_, err := e.SubmitBatchPin(context.Background(), nil, &fftypes.Identity{OnChain: addr}, batch)
+	err := e.SubmitBatchPin(context.Background(), nil, &fftypes.Identity{OnChain: addr}, batch)
 
 	assert.Regexp(t, "FF10111", err)
 	assert.Regexp(t, "pop", err)

--- a/internal/broadcast/manager.go
+++ b/internal/broadcast/manager.go
@@ -94,6 +94,59 @@ func (bm *broadcastManager) GetNodeSigningIdentity(ctx context.Context) (*fftype
 	return id, nil
 }
 
+func SubmitPinnedBatch(ctx context.Context, bi blockchain.Plugin, id identity.Plugin, db database.Plugin, batch *fftypes.Batch, contexts []*fftypes.Bytes32) error {
+
+	signingIdentity, err := id.Resolve(ctx, batch.Author)
+	if err == nil {
+		err = bi.VerifyIdentitySyntax(ctx, signingIdentity)
+	}
+	if err != nil {
+		log.L(ctx).Errorf("Invalid signing identity '%s': %s", batch.Author, err)
+		return err
+	}
+
+	tx := &fftypes.Transaction{
+		ID: batch.Payload.TX.ID,
+		Subject: fftypes.TransactionSubject{
+			Type:      fftypes.TransactionTypeBatchPin,
+			Namespace: batch.Namespace,
+			Signer:    signingIdentity.OnChain, // The transaction records on the on-chain identity
+			Reference: batch.ID,
+		},
+		Created: fftypes.Now(),
+		Status:  fftypes.OpStatusPending,
+	}
+	tx.Hash = tx.Subject.Hash()
+	err = db.UpsertTransaction(ctx, tx, true, false /* should be new, or idempotent replay */)
+	if err != nil {
+		return err
+	}
+
+	// Write the batch pin to the blockchain
+	blockchainTrackingID, err := bi.SubmitBatchPin(ctx, nil, signingIdentity, &blockchain.BatchPin{
+		Namespace:      batch.Namespace,
+		TransactionID:  batch.Payload.TX.ID,
+		BatchID:        batch.ID,
+		BatchHash:      batch.Hash,
+		BatchPaylodRef: batch.PayloadRef,
+		Contexts:       contexts,
+	})
+	if err != nil {
+		return err
+	}
+
+	// The pending blockchain transaction
+	op := fftypes.NewTXOperation(
+		bi,
+		batch.Namespace,
+		batch.Payload.TX.ID,
+		blockchainTrackingID,
+		fftypes.OpTypeBlockchainBatchPin,
+		fftypes.OpStatusPending,
+		"")
+	return db.UpsertOperation(ctx, op, false)
+}
+
 func (bm *broadcastManager) dispatchBatch(ctx context.Context, batch *fftypes.Batch, pins []*fftypes.Bytes32) error {
 
 	// Serialize the full payload, which has already been sealed for us by the BatchManager
@@ -116,66 +169,14 @@ func (bm *broadcastManager) dispatchBatch(ctx context.Context, batch *fftypes.Ba
 
 func (bm *broadcastManager) submitTXAndUpdateDB(ctx context.Context, batch *fftypes.Batch, contexts []*fftypes.Bytes32) error {
 
-	id, err := bm.identity.Resolve(ctx, batch.Author)
-	if err == nil {
-		err = bm.blockchain.VerifyIdentitySyntax(ctx, id)
-	}
-	if err != nil {
-		log.L(ctx).Errorf("Invalid signing identity '%s': %s", batch.Author, err)
-		return err
-	}
-
-	tx := &fftypes.Transaction{
-		ID: batch.Payload.TX.ID,
-		Subject: fftypes.TransactionSubject{
-			Type:      fftypes.TransactionTypeBatchPin,
-			Namespace: batch.Namespace,
-			Signer:    id.OnChain, // The transaction records on the on-chain identity
-			Reference: batch.ID,
-		},
-		Created: fftypes.Now(),
-		Status:  fftypes.OpStatusPending,
-	}
-	tx.Hash = tx.Subject.Hash()
-	err = bm.database.UpsertTransaction(ctx, tx, true, false /* should be new, or idempotent replay */)
-	if err != nil {
-		return err
-	}
-
 	// Update the batch to store the payloadRef
-	err = bm.database.UpdateBatch(ctx, batch.ID, database.BatchQueryFactory.NewUpdate(ctx).Set("payloadref", batch.PayloadRef))
+	err := bm.database.UpdateBatch(ctx, batch.ID, database.BatchQueryFactory.NewUpdate(ctx).Set("payloadref", batch.PayloadRef))
 	if err != nil {
-		return err
-	}
-
-	// Write the batch pin to the blockchain
-	blockchainTrackingID, err := bm.blockchain.SubmitBatchPin(ctx, nil, id, &blockchain.BatchPin{
-		Namespace:      batch.Namespace,
-		TransactionID:  batch.Payload.TX.ID,
-		BatchID:        batch.ID,
-		BatchHash:      batch.Hash,
-		BatchPaylodRef: batch.PayloadRef,
-		Contexts:       contexts,
-	})
-	if err != nil {
-		return err
-	}
-
-	// The pending blockchain transaction
-	op := fftypes.NewTXOperation(
-		bm.blockchain,
-		batch.Namespace,
-		batch.Payload.TX.ID,
-		blockchainTrackingID,
-		fftypes.OpTypeBlockchainBatchPin,
-		fftypes.OpStatusPending,
-		"")
-	if err := bm.database.UpsertOperation(ctx, op, false); err != nil {
 		return err
 	}
 
 	// The completed PublicStorage upload
-	op = fftypes.NewTXOperation(
+	op := fftypes.NewTXOperation(
 		bm.publicstorage,
 		batch.Namespace,
 		batch.Payload.TX.ID,
@@ -183,7 +184,12 @@ func (bm *broadcastManager) submitTXAndUpdateDB(ctx context.Context, batch *ffty
 		fftypes.OpTypePublicStorageBatchBroadcast,
 		fftypes.OpStatusSucceeded, // Note we performed the action synchronously above
 		"")
-	return bm.database.UpsertOperation(ctx, op, false)
+	err = bm.database.UpsertOperation(ctx, op, false)
+	if err != nil {
+		return err
+	}
+
+	return SubmitPinnedBatch(ctx, bm.blockchain, bm.identity, bm.database, batch, contexts)
 }
 
 func (bm *broadcastManager) broadcastMessageCommon(ctx context.Context, msg *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {

--- a/internal/broadcast/manager.go
+++ b/internal/broadcast/manager.go
@@ -123,7 +123,7 @@ func SubmitPinnedBatch(ctx context.Context, bi blockchain.Plugin, id identity.Pl
 	}
 
 	// Write the batch pin to the blockchain
-	blockchainTrackingID, err := bi.SubmitBatchPin(ctx, nil, signingIdentity, &blockchain.BatchPin{
+	err = bi.SubmitBatchPin(ctx, nil, signingIdentity, &blockchain.BatchPin{
 		Namespace:      batch.Namespace,
 		TransactionID:  batch.Payload.TX.ID,
 		BatchID:        batch.ID,
@@ -140,7 +140,7 @@ func SubmitPinnedBatch(ctx context.Context, bi blockchain.Plugin, id identity.Pl
 		bi,
 		batch.Namespace,
 		batch.Payload.TX.ID,
-		blockchainTrackingID,
+		"",
 		fftypes.OpTypeBlockchainBatchPin,
 		fftypes.OpStatusPending,
 		"")

--- a/internal/broadcast/manager_test.go
+++ b/internal/broadcast/manager_test.go
@@ -232,6 +232,7 @@ func TestSubmitTXAndUpdateDBSubmitFail(t *testing.T) {
 	mdi.On("UpsertTransaction", mock.Anything, mock.Anything, true, false).Return(nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Once().Return(nil)
+	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Once().Return(nil)
 	bm.blockchain.(*blockchainmocks.Plugin).On("SubmitBatchPin", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 	bm.publicstorage.(*publicstoragemocks.Plugin).On("Name").Return("ut_publicstorage")
 

--- a/internal/broadcast/manager_test.go
+++ b/internal/broadcast/manager_test.go
@@ -232,7 +232,7 @@ func TestSubmitTXAndUpdateDBSubmitFail(t *testing.T) {
 	mdi.On("UpsertTransaction", mock.Anything, mock.Anything, true, false).Return(nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Once().Return(nil)
-	bm.blockchain.(*blockchainmocks.Plugin).On("SubmitBatchPin", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("pop"))
+	bm.blockchain.(*blockchainmocks.Plugin).On("SubmitBatchPin", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 	bm.publicstorage.(*publicstoragemocks.Plugin).On("Name").Return("ut_publicstorage")
 
 	err := bm.submitTXAndUpdateDB(context.Background(), &fftypes.Batch{Author: "UTNodeID"}, []*fftypes.Bytes32{fftypes.NewRandB32()})
@@ -277,7 +277,7 @@ func TestSubmitTXAndUpdateDBAddOp2Fail(t *testing.T) {
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Once().Return(nil)
 	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Once().Return(fmt.Errorf("pop"))
-	mbi.On("SubmitBatchPin", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("txid", nil)
+	mbi.On("SubmitBatchPin", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mbi.On("Name").Return("ut_blockchain")
 
 	bm.publicstorage.(*publicstoragemocks.Plugin).On("Name").Return("ut_publicstorage")
@@ -307,7 +307,7 @@ func TestSubmitTXAndUpdateDBSucceed(t *testing.T) {
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Once().Return(nil)
 	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Once().Return(nil)
-	mbi.On("SubmitBatchPin", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("blockchain_id", nil)
+	mbi.On("SubmitBatchPin", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	bm.publicstorage.(*publicstoragemocks.Plugin).On("Name").Return("ut_publicstorage")
 
@@ -340,6 +340,6 @@ func TestSubmitTXAndUpdateDBSucceed(t *testing.T) {
 	op2 := mdi.Calls[3].Arguments[1].(*fftypes.Operation)
 	assert.Equal(t, *batch.Payload.TX.ID, *op2.Transaction)
 	assert.Equal(t, "ut_blockchain", op2.Plugin)
-	assert.Equal(t, "blockchain_id", op2.BackendID)
+	assert.Equal(t, "", op2.BackendID)
 	assert.Equal(t, fftypes.OpTypeBlockchainBatchPin, op2.Type)
 }

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -52,7 +52,7 @@ type EventManager interface {
 	WaitStop()
 
 	// Bound blockchain callbacks
-	TxSubmissionUpdate(bi blockchain.Plugin, txTrackingID string, txState blockchain.TransactionStatus, protocolTxID, errorMessage string, additionalInfo fftypes.JSONObject) error
+	TxSubmissionUpdate(bi blockchain.Plugin, tx string, txState blockchain.TransactionStatus, protocolTxID, errorMessage string, additionalInfo fftypes.JSONObject) error
 	BatchPinComplete(bi blockchain.Plugin, batch *blockchain.BatchPin, signingIdentity string, protocolTxID string, additionalInfo fftypes.JSONObject) error
 
 	// Bound dataexchange callbacks

--- a/internal/events/transaction_update.go
+++ b/internal/events/transaction_update.go
@@ -37,7 +37,7 @@ func (em *eventManager) TxSubmissionUpdate(bi blockchain.Plugin, tx string, txSt
 		err = i18n.NewError(em.ctx, i18n.Msg404NotFound)
 	}
 	if err != nil {
-		log.L(em.ctx).Warnf("Failed to correlate tracking ID '%s' with a submitted operation", tx)
+		log.L(em.ctx).Debugf("TX '%s' submission update ignored, as it was not submitted by this node", tx)
 		return nil
 	}
 

--- a/internal/events/transaction_update.go
+++ b/internal/events/transaction_update.go
@@ -17,8 +17,6 @@
 package events
 
 import (
-	"fmt"
-
 	"github.com/hyperledger-labs/firefly/internal/i18n"
 	"github.com/hyperledger-labs/firefly/internal/log"
 	"github.com/hyperledger-labs/firefly/pkg/blockchain"
@@ -29,20 +27,15 @@ import (
 func (em *eventManager) TxSubmissionUpdate(bi blockchain.Plugin, tx string, txState fftypes.OpStatus, protocolTxID, errorMessage string, additionalInfo fftypes.JSONObject) error {
 
 	// Find a matching operation, for this plugin, with the specified ID.
-	// We retry a few times, as there's an outside possibility of the event arriving before we're finished persisting the operation itself
-	var operations []*fftypes.Operation
 	fb := database.OperationQueryFactory.NewFilter(em.ctx)
 	filter := fb.And(
 		fb.Eq("tx", tx),
 		fb.Eq("plugin", bi.Name()),
 	)
-	err := em.retry.Do(em.ctx, fmt.Sprintf("correlate tx %s", tx), func(attempt int) (retry bool, err error) {
-		operations, _, err = em.database.GetOperations(em.ctx, filter)
-		if err == nil && len(operations) == 0 {
-			err = i18n.NewError(em.ctx, i18n.Msg404NotFound)
-		}
-		return (err != nil && attempt <= em.opCorrelationRetries), err
-	})
+	operations, _, err := em.database.GetOperations(em.ctx, filter)
+	if err == nil && len(operations) == 0 {
+		err = i18n.NewError(em.ctx, i18n.Msg404NotFound)
+	}
 	if err != nil {
 		log.L(em.ctx).Warnf("Failed to correlate tracking ID '%s' with a submitted operation", tx)
 		return nil

--- a/internal/orchestrator/bound_callbacks.go
+++ b/internal/orchestrator/bound_callbacks.go
@@ -29,8 +29,8 @@ type boundCallbacks struct {
 	ei events.EventManager
 }
 
-func (bc *boundCallbacks) TxSubmissionUpdate(txTrackingID string, txState blockchain.TransactionStatus, protocolTxID, errorMessage string, additionalInfo fftypes.JSONObject) error {
-	return bc.ei.TxSubmissionUpdate(bc.bi, txTrackingID, txState, protocolTxID, errorMessage, additionalInfo)
+func (bc *boundCallbacks) TxSubmissionUpdate(tx string, txState blockchain.TransactionStatus, protocolTxID, errorMessage string, additionalInfo fftypes.JSONObject) error {
+	return bc.ei.TxSubmissionUpdate(bc.bi, tx, txState, protocolTxID, errorMessage, additionalInfo)
 }
 
 func (bc *boundCallbacks) BatchPinComplete(batch *blockchain.BatchPin, signingIdentity string, protocolTxID string, additionalInfo fftypes.JSONObject) error {

--- a/internal/privatemessaging/privatemessaging_test.go
+++ b/internal/privatemessaging/privatemessaging_test.go
@@ -154,9 +154,9 @@ func TestDispatchBatchWithBlobs(t *testing.T) {
 		assert.Equal(t, "ns1", bp.Namespace)
 		assert.Equal(t, []*fftypes.Bytes32{pin1, pin2}, bp.Contexts)
 		return true
-	})).Return("tracking3", nil)
+	})).Return(nil)
 	mdi.On("UpsertOperation", pm.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
-		return op.BackendID == "tracking3" && op.Type == fftypes.OpTypeBlockchainBatchPin
+		return op.Type == fftypes.OpTypeBlockchainBatchPin
 	}), false).Return(nil, nil)
 
 	err := pm.dispatchBatch(pm.ctx, &fftypes.Batch{
@@ -321,7 +321,7 @@ func TestWriteTransactionSubmitBatchPinFail(t *testing.T) {
 	mdi.On("UpsertTransaction", pm.ctx, mock.Anything, true, false).Return(nil)
 
 	mbi := pm.blockchain.(*blockchainmocks.Plugin)
-	mbi.On("SubmitBatchPin", pm.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("pop"))
+	mbi.On("SubmitBatchPin", pm.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 
 	err := pm.writeTransaction(pm.ctx, &fftypes.Batch{Author: "org1"}, []*fftypes.Bytes32{})
 	assert.Regexp(t, "pop", err)
@@ -335,7 +335,7 @@ func TestWriteTransactionUpsertOpFail(t *testing.T) {
 	mdi.On("UpsertTransaction", pm.ctx, mock.Anything, true, false).Return(nil)
 
 	mbi := pm.blockchain.(*blockchainmocks.Plugin)
-	mbi.On("SubmitBatchPin", pm.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("tracking1", nil)
+	mbi.On("SubmitBatchPin", pm.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	mdi.On("UpsertOperation", pm.ctx, mock.Anything, false).Return(fmt.Errorf("pop"))
 

--- a/internal/privatemessaging/privatemessaging_test.go
+++ b/internal/privatemessaging/privatemessaging_test.go
@@ -63,10 +63,6 @@ func newTestPrivateMessaging(t *testing.T) (*privateMessaging, func()) {
 		Identifier: "org1", OnChain: "0x12345",
 	}, nil).Maybe()
 	mbi.On("VerifyIdentitySyntax", ctx, mock.MatchedBy(func(i *fftypes.Identity) bool { return i.OnChain == "0x12345" })).Return(nil).Maybe()
-	mii.On("Resolve", ctx, "org1").Return(&fftypes.Identity{
-		Identifier: "org1", OnChain: "0x23456",
-	}, nil).Maybe()
-	mbi.On("VerifyIdentitySyntax", ctx, mock.MatchedBy(func(i *fftypes.Identity) bool { return i.OnChain == "0x23456" })).Return(nil).Maybe()
 
 	return pm.(*privateMessaging), cancel
 }
@@ -313,7 +309,7 @@ func TestWriteTransactionUpsertFail(t *testing.T) {
 	mdi := pm.database.(*databasemocks.Plugin)
 	mdi.On("UpsertTransaction", pm.ctx, mock.Anything, true, false).Return(fmt.Errorf("pop"))
 
-	err := pm.writeTransaction(pm.ctx, &fftypes.Identity{OnChain: "0x12345"}, &fftypes.Batch{}, []*fftypes.Bytes32{})
+	err := pm.writeTransaction(pm.ctx, &fftypes.Batch{Author: "org1"}, []*fftypes.Bytes32{})
 	assert.Regexp(t, "pop", err)
 }
 
@@ -327,7 +323,7 @@ func TestWriteTransactionSubmitBatchPinFail(t *testing.T) {
 	mbi := pm.blockchain.(*blockchainmocks.Plugin)
 	mbi.On("SubmitBatchPin", pm.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("pop"))
 
-	err := pm.writeTransaction(pm.ctx, &fftypes.Identity{OnChain: "0x12345"}, &fftypes.Batch{}, []*fftypes.Bytes32{})
+	err := pm.writeTransaction(pm.ctx, &fftypes.Batch{Author: "org1"}, []*fftypes.Bytes32{})
 	assert.Regexp(t, "pop", err)
 }
 
@@ -343,7 +339,7 @@ func TestWriteTransactionUpsertOpFail(t *testing.T) {
 
 	mdi.On("UpsertOperation", pm.ctx, mock.Anything, false).Return(fmt.Errorf("pop"))
 
-	err := pm.writeTransaction(pm.ctx, &fftypes.Identity{OnChain: "0x12345"}, &fftypes.Batch{}, []*fftypes.Bytes32{})
+	err := pm.writeTransaction(pm.ctx, &fftypes.Batch{Author: "org1"}, []*fftypes.Bytes32{})
 	assert.Regexp(t, "pop", err)
 }
 

--- a/internal/privatemessaging/privatemessaging_test.go
+++ b/internal/privatemessaging/privatemessaging_test.go
@@ -319,6 +319,7 @@ func TestWriteTransactionSubmitBatchPinFail(t *testing.T) {
 
 	mdi := pm.database.(*databasemocks.Plugin)
 	mdi.On("UpsertTransaction", pm.ctx, mock.Anything, true, false).Return(nil)
+	mdi.On("UpsertOperation", pm.ctx, mock.Anything, false).Return(nil)
 
 	mbi := pm.blockchain.(*blockchainmocks.Plugin)
 	mbi.On("SubmitBatchPin", pm.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))

--- a/mocks/blockchainmocks/callbacks.go
+++ b/mocks/blockchainmocks/callbacks.go
@@ -28,13 +28,13 @@ func (_m *Callbacks) BatchPinComplete(batch *blockchain.BatchPin, signingIdentit
 	return r0
 }
 
-// TxSubmissionUpdate provides a mock function with given fields: txTrackingID, txState, protocolTxID, errorMessage, additionalInfo
-func (_m *Callbacks) TxSubmissionUpdate(txTrackingID string, txState fftypes.OpStatus, protocolTxID string, errorMessage string, additionalInfo fftypes.JSONObject) error {
-	ret := _m.Called(txTrackingID, txState, protocolTxID, errorMessage, additionalInfo)
+// TxSubmissionUpdate provides a mock function with given fields: tx, txState, protocolTxID, errorMessage, additionalInfo
+func (_m *Callbacks) TxSubmissionUpdate(tx string, txState fftypes.OpStatus, protocolTxID string, errorMessage string, additionalInfo fftypes.JSONObject) error {
+	ret := _m.Called(tx, txState, protocolTxID, errorMessage, additionalInfo)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, fftypes.OpStatus, string, string, fftypes.JSONObject) error); ok {
-		r0 = rf(txTrackingID, txState, protocolTxID, errorMessage, additionalInfo)
+		r0 = rf(tx, txState, protocolTxID, errorMessage, additionalInfo)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/blockchainmocks/plugin.go
+++ b/mocks/blockchainmocks/plugin.go
@@ -82,24 +82,17 @@ func (_m *Plugin) Start() error {
 }
 
 // SubmitBatchPin provides a mock function with given fields: ctx, ledgerID, identity, batch
-func (_m *Plugin) SubmitBatchPin(ctx context.Context, ledgerID *fftypes.UUID, identity *fftypes.Identity, batch *blockchain.BatchPin) (string, error) {
+func (_m *Plugin) SubmitBatchPin(ctx context.Context, ledgerID *fftypes.UUID, identity *fftypes.Identity, batch *blockchain.BatchPin) error {
 	ret := _m.Called(ctx, ledgerID, identity, batch)
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID, *fftypes.Identity, *blockchain.BatchPin) string); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID, *fftypes.Identity, *blockchain.BatchPin) error); ok {
 		r0 = rf(ctx, ledgerID, identity, batch)
 	} else {
-		r0 = ret.Get(0).(string)
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.UUID, *fftypes.Identity, *blockchain.BatchPin) error); ok {
-		r1 = rf(ctx, ledgerID, identity, batch)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // VerifyIdentitySyntax provides a mock function with given fields: ctx, identity

--- a/mocks/eventmocks/event_manager.go
+++ b/mocks/eventmocks/event_manager.go
@@ -229,13 +229,13 @@ func (_m *EventManager) TransferResult(dx dataexchange.Plugin, trackingID string
 	return r0
 }
 
-// TxSubmissionUpdate provides a mock function with given fields: bi, txTrackingID, txState, protocolTxID, errorMessage, additionalInfo
-func (_m *EventManager) TxSubmissionUpdate(bi blockchain.Plugin, txTrackingID string, txState fftypes.OpStatus, protocolTxID string, errorMessage string, additionalInfo fftypes.JSONObject) error {
-	ret := _m.Called(bi, txTrackingID, txState, protocolTxID, errorMessage, additionalInfo)
+// TxSubmissionUpdate provides a mock function with given fields: bi, tx, txState, protocolTxID, errorMessage, additionalInfo
+func (_m *EventManager) TxSubmissionUpdate(bi blockchain.Plugin, tx string, txState fftypes.OpStatus, protocolTxID string, errorMessage string, additionalInfo fftypes.JSONObject) error {
+	ret := _m.Called(bi, tx, txState, protocolTxID, errorMessage, additionalInfo)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(blockchain.Plugin, string, fftypes.OpStatus, string, string, fftypes.JSONObject) error); ok {
-		r0 = rf(bi, txTrackingID, txState, protocolTxID, errorMessage, additionalInfo)
+		r0 = rf(bi, tx, txState, protocolTxID, errorMessage, additionalInfo)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/blockchain/plugin.go
+++ b/pkg/blockchain/plugin.go
@@ -46,7 +46,7 @@ type Plugin interface {
 
 	// SubmitBatchPin sequences a batch of message globally to all viewers of a given ledger
 	// The returned tracking ID will be used to correlate with any subsequent transaction tracking updates
-	SubmitBatchPin(ctx context.Context, ledgerID *fftypes.UUID, identity *fftypes.Identity, batch *BatchPin) (txTrackingID string, err error)
+	SubmitBatchPin(ctx context.Context, ledgerID *fftypes.UUID, identity *fftypes.Identity, batch *BatchPin) error
 }
 
 // Callbacks is the interface provided to the blockchain plugin, to allow it to pass events back to firefly.
@@ -61,7 +61,7 @@ type Callbacks interface {
 	// Only the party submitting the transaction will see this data.
 	//
 	// Error should will only be returned in shutdown scenarios
-	TxSubmissionUpdate(txTrackingID string, txState TransactionStatus, protocolTxID, errorMessage string, additionalInfo fftypes.JSONObject) error
+	TxSubmissionUpdate(tx string, txState TransactionStatus, protocolTxID, errorMessage string, additionalInfo fftypes.JSONObject) error
 
 	// BatchPinComplete notifies on the arrival of a sequenced batch of messages, which might have been
 	// submitted by us, or by any other authorized party in the network.


### PR DESCRIPTION
Counterpart to https://github.com/hyperledger-labs/firefly-ethconnect/pull/139.

This will reduce the noisy logs when using tokens, because tokens generates ethconnect events that are "unexpected" from the perspective of the blockchain plugin. There will still be a single warning printed for each token transaction, but that's...a little better?