### PR TITLE
Make sync-async helpers less specific to messaging

### DIFF
--- a/internal/syncasync/sync_async_bridge_test.go
+++ b/internal/syncasync/sync_async_bridge_test.go
@@ -450,12 +450,12 @@ func TestEventCallbackMsgDataLookupFail(t *testing.T) {
 	mdm := sa.data.(*datamocks.Manager)
 	mdm.On("GetMessageData", sa.ctx, mock.Anything, true).Return(nil, false, fmt.Errorf("pop"))
 
-	sa.resolveInflight(&inflightRequest{}, &fftypes.Message{
+	sa.resolveReply(&inflightRequest{}, &fftypes.Message{
 		Header: fftypes.MessageHeader{
 			ID:  fftypes.NewUUID(),
 			CID: fftypes.NewUUID(),
 		},
-	}, true, nil)
+	})
 
 	mdm.AssertExpectations(t)
 }


### PR DESCRIPTION
This changeset simplifies the `inflightRequest` interface and adds 3 new generic constructs:
* `inflightResponse`
* `requestType`
* `requestSender`

The core helpers of sync-async (`sendAndWait` and `eventCallback`) now deal with these generic types and perform much less messaging-specific inspection of the requests and responses. There are clearer extension points for new request-response flows that may or may not relate to messaging at all.

The end goal is that this will make it easier to wrap tokens (and other future operations) in sync-async handlers.