### PR TITLE
Add an "id" parameter to SendMessageWithID

### DIFF
--- a/internal/broadcast/manager.go
+++ b/internal/broadcast/manager.go
@@ -39,7 +39,7 @@ type Manager interface {
 	BroadcastDatatype(ctx context.Context, ns string, datatype *fftypes.Datatype, waitConfirm bool) (msg *fftypes.Message, err error)
 	BroadcastNamespace(ctx context.Context, ns *fftypes.Namespace, waitConfirm bool) (msg *fftypes.Message, err error)
 	BroadcastMessage(ctx context.Context, ns string, in *fftypes.MessageInOut, waitConfirm bool) (out *fftypes.Message, err error)
-	BroadcastMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error)
+	BroadcastMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error)
 	BroadcastDefinition(ctx context.Context, def fftypes.Definition, signingIdentity *fftypes.Identity, tag fftypes.SystemTag, waitConfirm bool) (msg *fftypes.Message, err error)
 	GetNodeSigningIdentity(ctx context.Context) (*fftypes.Identity, error)
 	Start() error

--- a/internal/broadcast/message.go
+++ b/internal/broadcast/message.go
@@ -27,14 +27,14 @@ import (
 )
 
 func (bm *broadcastManager) BroadcastMessage(ctx context.Context, ns string, in *fftypes.MessageInOut, waitConfirm bool) (out *fftypes.Message, err error) {
-	in.Header.ID = nil
-	return bm.BroadcastMessageWithID(ctx, ns, in, nil, waitConfirm)
+	return bm.BroadcastMessageWithID(ctx, ns, nil, in, nil, waitConfirm)
 }
 
-func (bm *broadcastManager) BroadcastMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error) {
+func (bm *broadcastManager) BroadcastMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error) {
 	if unresolved != nil {
 		resolved = &unresolved.Message
 	}
+	resolved.Header.ID = id
 	resolved.Header.Namespace = ns
 	resolved.Header.Type = fftypes.MessageTypeBroadcast
 	if resolved.Header.Author == "" {

--- a/internal/privatemessaging/message.go
+++ b/internal/privatemessaging/message.go
@@ -26,15 +26,15 @@ import (
 )
 
 func (pm *privateMessaging) SendMessage(ctx context.Context, ns string, in *fftypes.MessageInOut, waitConfirm bool) (out *fftypes.Message, err error) {
-	in.Header.ID = nil
-	return pm.SendMessageWithID(ctx, ns, in, nil, waitConfirm)
+	return pm.SendMessageWithID(ctx, ns, nil, in, nil, waitConfirm)
 }
 
-func (pm *privateMessaging) SendMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
+func (pm *privateMessaging) SendMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
 	if unresolved != nil {
 		resolved = &unresolved.Message
 	}
 
+	resolved.Header.ID = id
 	resolved.Header.Namespace = ns
 	resolved.Header.Type = fftypes.MessageTypePrivate
 	if resolved.Header.Author == "" {

--- a/internal/privatemessaging/privatemessaging.go
+++ b/internal/privatemessaging/privatemessaging.go
@@ -41,7 +41,7 @@ type Manager interface {
 
 	Start() error
 	SendMessage(ctx context.Context, ns string, in *fftypes.MessageInOut, waitConfirm bool) (out *fftypes.Message, err error)
-	SendMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error)
+	SendMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error)
 }
 
 type privateMessaging struct {

--- a/internal/syncasync/sync_async_bridge.go
+++ b/internal/syncasync/sync_async_bridge.go
@@ -253,8 +253,7 @@ func (sa *syncAsyncBridge) RequestReply(ctx context.Context, ns string, unresolv
 	}
 
 	reply, err := sa.sendAndWait(ctx, ns, messageReply, func(requestID *fftypes.UUID) error {
-		unresolved.Message.Header.ID = requestID
-		_, err := sa.sender.SendMessageWithID(ctx, ns, unresolved, &unresolved.Message, false)
+		_, err := sa.sender.SendMessageWithID(ctx, ns, requestID, unresolved, &unresolved.Message, false)
 		return err
 	})
 	if err != nil {
@@ -265,8 +264,7 @@ func (sa *syncAsyncBridge) RequestReply(ctx context.Context, ns string, unresolv
 
 func (sa *syncAsyncBridge) SendConfirm(ctx context.Context, msg *fftypes.Message) (*fftypes.Message, error) {
 	reply, err := sa.sendAndWait(ctx, msg.Header.Namespace, messageConfirm, func(requestID *fftypes.UUID) error {
-		msg.Header.ID = requestID
-		_, err := sa.sender.SendMessageWithID(ctx, msg.Header.Namespace, nil, msg, false)
+		_, err := sa.sender.SendMessageWithID(ctx, msg.Header.Namespace, requestID, nil, msg, false)
 		return err
 	})
 	if err != nil {

--- a/internal/syshandlers/syshandler.go
+++ b/internal/syshandlers/syshandler.go
@@ -75,14 +75,14 @@ func (sh *systemHandlers) EnsureLocalGroup(ctx context.Context, group *fftypes.G
 	return sh.messaging.EnsureLocalGroup(ctx, group)
 }
 
-func (sh *systemHandlers) SendMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error) {
+func (sh *systemHandlers) SendMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error) {
 	if resolved == nil {
 		resolved = &unresolved.Message
 	}
 	if resolved.Header.Group == nil && (unresolved == nil || unresolved.Group == nil) {
-		return sh.broadcast.BroadcastMessageWithID(ctx, ns, unresolved, resolved, waitConfirm)
+		return sh.broadcast.BroadcastMessageWithID(ctx, ns, id, unresolved, resolved, waitConfirm)
 	}
-	return sh.messaging.SendMessageWithID(ctx, ns, unresolved, resolved, waitConfirm)
+	return sh.messaging.SendMessageWithID(ctx, ns, id, unresolved, resolved, waitConfirm)
 }
 
 func (sh *systemHandlers) HandleSystemBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (valid bool, err error) {

--- a/internal/syshandlers/syshandler_test.go
+++ b/internal/syshandlers/syshandler_test.go
@@ -75,26 +75,28 @@ func TestGetSystemBroadcastPayloadBadJSON(t *testing.T) {
 func TestPrivateMessagingPassthroughs(t *testing.T) {
 	ctx := context.Background()
 
+	requestID := fftypes.NewUUID()
+
 	sh := newTestSystemHandlers(t)
 	mpm := sh.messaging.(*privatemessagingmocks.Manager)
 	mpm.On("GetGroupByID", ctx, mock.Anything).Return(nil, nil)
 	mpm.On("GetGroups", ctx, mock.Anything).Return(nil, nil, nil)
 	mpm.On("ResolveInitGroup", ctx, mock.Anything).Return(nil, nil)
 	mpm.On("EnsureLocalGroup", ctx, mock.Anything).Return(false, nil)
-	mpm.On("SendMessageWithID", ctx, "ns1", mock.Anything, mock.Anything, false).Return(nil, nil)
+	mpm.On("SendMessageWithID", ctx, "ns1", requestID, mock.Anything, mock.Anything, false).Return(nil, nil)
 	mbm := sh.broadcast.(*broadcastmocks.Manager)
-	mbm.On("BroadcastMessageWithID", ctx, "ns1", mock.Anything, mock.Anything, false).Return(nil, nil)
+	mbm.On("BroadcastMessageWithID", ctx, "ns1", requestID, mock.Anything, mock.Anything, false).Return(nil, nil)
 
 	_, _ = sh.GetGroupByID(ctx, fftypes.NewUUID().String())
 	_, _, _ = sh.GetGroups(ctx, nil)
 	_, _ = sh.ResolveInitGroup(ctx, nil)
 	_, _ = sh.EnsureLocalGroup(ctx, nil)
-	_, _ = sh.SendMessageWithID(ctx, "ns1", nil, &fftypes.Message{
+	_, _ = sh.SendMessageWithID(ctx, "ns1", requestID, nil, &fftypes.Message{
 		Header: fftypes.MessageHeader{
 			Namespace: "ns1",
 		},
 	}, false)
-	_, _ = sh.SendMessageWithID(ctx, "ns1", &fftypes.MessageInOut{
+	_, _ = sh.SendMessageWithID(ctx, "ns1", requestID, &fftypes.MessageInOut{
 		Message: fftypes.Message{
 			Header: fftypes.MessageHeader{
 				Namespace: "ns1",

--- a/internal/sysmessaging/msgsender.go
+++ b/internal/sysmessaging/msgsender.go
@@ -24,6 +24,6 @@ import (
 
 // MessageSender specifies the sending interfaces of performing a send, without creating a cycle.
 type MessageSender interface {
-	SendMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error)
+	SendMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (out *fftypes.Message, err error)
 	SendReply(ctx context.Context, event *fftypes.Event, reply *fftypes.MessageInOut)
 }

--- a/mocks/broadcastmocks/manager.go
+++ b/mocks/broadcastmocks/manager.go
@@ -83,13 +83,13 @@ func (_m *Manager) BroadcastMessage(ctx context.Context, ns string, in *fftypes.
 	return r0, r1
 }
 
-// BroadcastMessageWithID provides a mock function with given fields: ctx, ns, unresolved, resolved, waitConfirm
-func (_m *Manager) BroadcastMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
-	ret := _m.Called(ctx, ns, unresolved, resolved, waitConfirm)
+// BroadcastMessageWithID provides a mock function with given fields: ctx, ns, id, unresolved, resolved, waitConfirm
+func (_m *Manager) BroadcastMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
+	ret := _m.Called(ctx, ns, id, unresolved, resolved, waitConfirm)
 
 	var r0 *fftypes.Message
-	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.MessageInOut, *fftypes.Message, bool) *fftypes.Message); ok {
-		r0 = rf(ctx, ns, unresolved, resolved, waitConfirm)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID, *fftypes.MessageInOut, *fftypes.Message, bool) *fftypes.Message); ok {
+		r0 = rf(ctx, ns, id, unresolved, resolved, waitConfirm)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.Message)
@@ -97,8 +97,8 @@ func (_m *Manager) BroadcastMessageWithID(ctx context.Context, ns string, unreso
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.MessageInOut, *fftypes.Message, bool) error); ok {
-		r1 = rf(ctx, ns, unresolved, resolved, waitConfirm)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.UUID, *fftypes.MessageInOut, *fftypes.Message, bool) error); ok {
+		r1 = rf(ctx, ns, id, unresolved, resolved, waitConfirm)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/privatemessagingmocks/manager.go
+++ b/mocks/privatemessagingmocks/manager.go
@@ -138,13 +138,13 @@ func (_m *Manager) SendMessage(ctx context.Context, ns string, in *fftypes.Messa
 	return r0, r1
 }
 
-// SendMessageWithID provides a mock function with given fields: ctx, ns, unresolved, resolved, waitConfirm
-func (_m *Manager) SendMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
-	ret := _m.Called(ctx, ns, unresolved, resolved, waitConfirm)
+// SendMessageWithID provides a mock function with given fields: ctx, ns, id, unresolved, resolved, waitConfirm
+func (_m *Manager) SendMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
+	ret := _m.Called(ctx, ns, id, unresolved, resolved, waitConfirm)
 
 	var r0 *fftypes.Message
-	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.MessageInOut, *fftypes.Message, bool) *fftypes.Message); ok {
-		r0 = rf(ctx, ns, unresolved, resolved, waitConfirm)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID, *fftypes.MessageInOut, *fftypes.Message, bool) *fftypes.Message); ok {
+		r0 = rf(ctx, ns, id, unresolved, resolved, waitConfirm)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.Message)
@@ -152,8 +152,8 @@ func (_m *Manager) SendMessageWithID(ctx context.Context, ns string, unresolved 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.MessageInOut, *fftypes.Message, bool) error); ok {
-		r1 = rf(ctx, ns, unresolved, resolved, waitConfirm)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.UUID, *fftypes.MessageInOut, *fftypes.Message, bool) error); ok {
+		r1 = rf(ctx, ns, id, unresolved, resolved, waitConfirm)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/syshandlersmocks/system_handlers.go
+++ b/mocks/syshandlersmocks/system_handlers.go
@@ -136,13 +136,13 @@ func (_m *SystemHandlers) ResolveInitGroup(ctx context.Context, msg *fftypes.Mes
 	return r0, r1
 }
 
-// SendMessageWithID provides a mock function with given fields: ctx, ns, unresolved, resolved, waitConfirm
-func (_m *SystemHandlers) SendMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
-	ret := _m.Called(ctx, ns, unresolved, resolved, waitConfirm)
+// SendMessageWithID provides a mock function with given fields: ctx, ns, id, unresolved, resolved, waitConfirm
+func (_m *SystemHandlers) SendMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
+	ret := _m.Called(ctx, ns, id, unresolved, resolved, waitConfirm)
 
 	var r0 *fftypes.Message
-	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.MessageInOut, *fftypes.Message, bool) *fftypes.Message); ok {
-		r0 = rf(ctx, ns, unresolved, resolved, waitConfirm)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID, *fftypes.MessageInOut, *fftypes.Message, bool) *fftypes.Message); ok {
+		r0 = rf(ctx, ns, id, unresolved, resolved, waitConfirm)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.Message)
@@ -150,8 +150,8 @@ func (_m *SystemHandlers) SendMessageWithID(ctx context.Context, ns string, unre
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.MessageInOut, *fftypes.Message, bool) error); ok {
-		r1 = rf(ctx, ns, unresolved, resolved, waitConfirm)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.UUID, *fftypes.MessageInOut, *fftypes.Message, bool) error); ok {
+		r1 = rf(ctx, ns, id, unresolved, resolved, waitConfirm)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/sysmessagingmocks/message_sender.go
+++ b/mocks/sysmessagingmocks/message_sender.go
@@ -14,13 +14,13 @@ type MessageSender struct {
 	mock.Mock
 }
 
-// SendMessageWithID provides a mock function with given fields: ctx, ns, unresolved, resolved, waitConfirm
-func (_m *MessageSender) SendMessageWithID(ctx context.Context, ns string, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
-	ret := _m.Called(ctx, ns, unresolved, resolved, waitConfirm)
+// SendMessageWithID provides a mock function with given fields: ctx, ns, id, unresolved, resolved, waitConfirm
+func (_m *MessageSender) SendMessageWithID(ctx context.Context, ns string, id *fftypes.UUID, unresolved *fftypes.MessageInOut, resolved *fftypes.Message, waitConfirm bool) (*fftypes.Message, error) {
+	ret := _m.Called(ctx, ns, id, unresolved, resolved, waitConfirm)
 
 	var r0 *fftypes.Message
-	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.MessageInOut, *fftypes.Message, bool) *fftypes.Message); ok {
-		r0 = rf(ctx, ns, unresolved, resolved, waitConfirm)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID, *fftypes.MessageInOut, *fftypes.Message, bool) *fftypes.Message); ok {
+		r0 = rf(ctx, ns, id, unresolved, resolved, waitConfirm)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.Message)
@@ -28,8 +28,8 @@ func (_m *MessageSender) SendMessageWithID(ctx context.Context, ns string, unres
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.MessageInOut, *fftypes.Message, bool) error); ok {
-		r1 = rf(ctx, ns, unresolved, resolved, waitConfirm)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.UUID, *fftypes.MessageInOut, *fftypes.Message, bool) error); ok {
+		r1 = rf(ctx, ns, id, unresolved, resolved, waitConfirm)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
Given the method naming, it feels more intuitive to pass this in (rather
than requiring the sender to set it on a nested field before invoking).

Signed-off-by: Andrew Richardson <andrew.richardson@kaleido.io>