### PR TITLE
Add maintainers as CODEOWNERS for /docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 * @peterbroadhurst @nguyer @awrichar
 
 # FireFly Documentation Maintainers
-/docs @nickgaski
+/docs @peterbroadhurst @nguyer @awrichar @nickgaski


### PR DESCRIPTION
This should fix the issue of requiring Nick's approval for anything that touches `/docs`. The intention was that he _could_ approve anything that _only_ modified `/docs`, but the way `CODEOWNERS` works, only the last rule to match gets applied, which meant global owners couldn't approve anything in `/docs`. I think this is the simplest solution to achieve what we want.