### PR TITLE
Align the "additional info" for blockchain and token transactions

### DIFF
--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -324,6 +324,7 @@ func (e *Ethereum) handleBatchPinEvent(ctx context.Context, msgJSON fftypes.JSON
 	}
 
 	// If there's an error dispatching the event, we must return the error and shutdown
+	delete(msgJSON, "data")
 	return e.callbacks.BatchPinComplete(batch, authorAddress, sTransactionHash, msgJSON)
 }
 

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -549,6 +549,27 @@ func TestHandleMessageBatchPinOK(t *testing.T) {
 	assert.Equal(t, "68e4da79f805bca5b912bcda9c63d03e6e867108dabb9b944109aea541ef522a", b.Contexts[0].String())
 	assert.Equal(t, "19b82093de5ce92a01e333048e877e2374354bf846dd034864ef6ffbd6438771", b.Contexts[1].String())
 
+	info1 := fftypes.JSONObject{
+		"address":          "0x1C197604587F046FD40684A8f21f4609FB811A7b",
+		"blockNumber":      "38011",
+		"logIndex":         "50",
+		"signature":        "BatchPin(address,uint256,string,bytes32,bytes32,string,bytes32[])",
+		"subID":            "sb-b5b97a4e-a317-4053-6400-1474650efcb5",
+		"transactionHash":  "0xc26df2bf1a733e9249372d61eb11bd8662d26c8129df76890b1beb2f6fa72628",
+		"transactionIndex": "0x0",
+	}
+	assert.Equal(t, info1, em.Calls[0].Arguments[3])
+	info2 := fftypes.JSONObject{
+		"address":          "0x1C197604587F046FD40684A8f21f4609FB811A7b",
+		"blockNumber":      "38011",
+		"logIndex":         "51",
+		"signature":        "BatchPin(address,uint256,string,bytes32,bytes32,string,bytes32[])",
+		"subID":            "sb-b5b97a4e-a317-4053-6400-1474650efcb5",
+		"transactionHash":  "0x0c50dff0893e795293189d9cc5ba0d63c4020d8758ace4a69d02c9d6d43cb695",
+		"transactionIndex": "0x1",
+	}
+	assert.Equal(t, info2, em.Calls[1].Arguments[3])
+
 	em.AssertExpectations(t)
 
 }

--- a/internal/tokens/https/https.go
+++ b/internal/tokens/https/https.go
@@ -162,7 +162,7 @@ func (h *HTTPS) handleTokenPoolCreate(ctx context.Context, data fftypes.JSONObje
 	}
 
 	// If there's an error dispatching the event, we must return the error and shutdown
-	return h.callbacks.TokenPoolCreated(h, pool, authorAddress, txHash, data)
+	return h.callbacks.TokenPoolCreated(h, pool, authorAddress, txHash, tx)
 }
 
 func (h *HTTPS) eventLoop() {

--- a/internal/tokens/https/https_test.go
+++ b/internal/tokens/https/https_test.go
@@ -205,7 +205,8 @@ func TestEvents(t *testing.T) {
 	// token-pool: success
 	mcb.On("TokenPoolCreated", h, mock.MatchedBy(func(pool *fftypes.TokenPool) bool {
 		return pool.Namespace == "ns1" && pool.Name == "test-pool" && pool.Type == fftypes.TokenTypeFungible && pool.ProtocolID == "F1" && *pool.ID == *id2 && *pool.TX.ID == *id1
-	}), "0x0", "abc", mock.Anything).Return(nil)
+	}), "0x0", "abc", fftypes.JSONObject{"transactionHash": "abc"},
+	).Return(nil)
 	fromServer <- `{"id":"7","event":"token-pool","data":{"namespace":"ns1","name":"test-pool","clientId":"` + hex.EncodeToString(uuids[0:32]) + `","type":"fungible","poolId":"F1","author":"0x0","transaction":{"transactionHash":"abc"}}}`
 	msg = <-toServer
 	assert.Equal(t, `{"data":{"id":"7"},"event":"ack"}`, string(msg))


### PR DESCRIPTION
Both will contain keys for blockNumber, transactionIndex, and transactionHash
(at least on Ethereum). Prune higher and lower level nested items from the
JSON body.