### PR TITLE
Add additional fields to TokenPool

### DIFF
--- a/db/migrations/postgres/000028_add_tokenpool_fields.down.sql
+++ b/db/migrations/postgres/000028_add_tokenpool_fields.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+ALTER TABLE tokenpool DROP COLUMN connector;
+ALTER TABLE tokenpool DROP COLUMN symbol;
+ALTER TABLE tokenpool DROP COLUMN message_id;
+COMMIT;

--- a/db/migrations/postgres/000028_add_tokenpool_fields.up.sql
+++ b/db/migrations/postgres/000028_add_tokenpool_fields.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+DELETE FROM tokenpool;
+ALTER TABLE tokenpool ADD COLUMN connector VARCHAR(64) NOT NULL;
+ALTER TABLE tokenpool ADD COLUMN symbol VARCHAR(64);
+ALTER TABLE tokenpool ADD COLUMN message_id UUID;
+COMMIT;

--- a/db/migrations/sqlite/000028_add_tokenpool_fields.down.sql
+++ b/db/migrations/sqlite/000028_add_tokenpool_fields.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tokenpool DROP COLUMN connector;
+ALTER TABLE tokenpool DROP COLUMN symbol;
+ALTER TABLE tokenpool DROP COLUMN message_id;

--- a/db/migrations/sqlite/000028_add_tokenpool_fields.up.sql
+++ b/db/migrations/sqlite/000028_add_tokenpool_fields.up.sql
@@ -1,0 +1,4 @@
+DELETE FROM tokenpool;
+ALTER TABLE tokenpool ADD COLUMN connector VARCHAR(64) NOT NULL;
+ALTER TABLE tokenpool ADD COLUMN symbol VARCHAR(64);
+ALTER TABLE tokenpool ADD COLUMN message_id UUID;

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -4228,6 +4228,11 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: message
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: name
         schema:
           type: string
@@ -4239,6 +4244,11 @@ paths:
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
         name: protocolid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: symbol
         schema:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
@@ -4289,12 +4299,17 @@ paths:
                   properties:
                     author:
                       type: string
+                    connector:
+                      type: string
                     id: {}
+                    message: {}
                     name:
                       type: string
                     namespace:
                       type: string
                     protocolId:
+                      type: string
+                    symbol:
                       type: string
                     tx:
                       properties:
@@ -4347,6 +4362,8 @@ paths:
                   type: string
                 name:
                   type: string
+                symbol:
+                  type: string
                 type:
                   enum:
                   - fungible
@@ -4361,12 +4378,17 @@ paths:
                 properties:
                   author:
                     type: string
+                  connector:
+                    type: string
                   id: {}
+                  message: {}
                   name:
                     type: string
                   namespace:
                     type: string
                   protocolId:
+                    type: string
+                  symbol:
                     type: string
                   tx:
                     properties:
@@ -4385,12 +4407,17 @@ paths:
                 properties:
                   author:
                     type: string
+                  connector:
+                    type: string
                   id: {}
+                  message: {}
                   name:
                     type: string
                   namespace:
                     type: string
                   protocolId:
+                    type: string
+                  symbol:
                     type: string
                   tx:
                     properties:
@@ -4443,12 +4470,17 @@ paths:
                 properties:
                   author:
                     type: string
+                  connector:
+                    type: string
                   id: {}
+                  message: {}
                   name:
                     type: string
                   namespace:
                     type: string
                   protocolId:
+                    type: string
+                  symbol:
                     type: string
                   tx:
                     properties:

--- a/internal/apiserver/route_post_token_pool.go
+++ b/internal/apiserver/route_post_token_pool.go
@@ -40,7 +40,7 @@ var postTokenPool = &oapispec.Route{
 	FilterFactory:   nil,
 	Description:     i18n.MsgTBD,
 	JSONInputValue:  func() interface{} { return &fftypes.TokenPool{} },
-	JSONInputMask:   []string{"ID", "Namespace", "ProtocolID", "TX"},
+	JSONInputMask:   []string{"ID", "Namespace", "ProtocolID", "TX", "Connector", "Message"},
 	JSONOutputValue: func() interface{} { return &fftypes.TokenPool{} },
 	JSONOutputCodes: []int{http.StatusAccepted, http.StatusOK},
 	JSONHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {

--- a/internal/database/sqlcommon/tokenpool_sql.go
+++ b/internal/database/sqlcommon/tokenpool_sql.go
@@ -34,11 +34,15 @@ var (
 		"name",
 		"protocol_id",
 		"type",
+		"connector",
+		"symbol",
+		"message_id",
 		"tx_type",
 		"tx_id",
 	}
 	tokenPoolFilterFieldMap = map[string]string{
 		"protocolid":       "protocol_id",
+		"message":          "message_id",
 		"transaction.type": "tx_type",
 		"transaction.id":   "tx_id",
 	}
@@ -79,6 +83,9 @@ func (s *SQLCommon) UpsertTokenPool(ctx context.Context, pool *fftypes.TokenPool
 				Set("name", pool.Name).
 				Set("protocol_id", pool.ProtocolID).
 				Set("type", pool.Type).
+				Set("connector", pool.Connector).
+				Set("symbol", pool.Symbol).
+				Set("message_id", pool.Message).
 				Set("tx_type", pool.TX.Type).
 				Set("tx_id", pool.TX.ID).
 				Where(sq.Eq{"id": pool.ID}),
@@ -98,6 +105,9 @@ func (s *SQLCommon) UpsertTokenPool(ctx context.Context, pool *fftypes.TokenPool
 					pool.Name,
 					pool.ProtocolID,
 					pool.Type,
+					pool.Connector,
+					pool.Symbol,
+					pool.Message,
 					pool.TX.Type,
 					pool.TX.ID,
 				),
@@ -120,6 +130,9 @@ func (s *SQLCommon) tokenPoolResult(ctx context.Context, row *sql.Rows) (*fftype
 		&pool.Name,
 		&pool.ProtocolID,
 		&pool.Type,
+		&pool.Connector,
+		&pool.Symbol,
+		&pool.Message,
 		&pool.TX.Type,
 		&pool.TX.ID,
 	)

--- a/internal/database/sqlcommon/tokenpool_sql_test.go
+++ b/internal/database/sqlcommon/tokenpool_sql_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestTokenPoolE2EWithDB(t *testing.T) {
-
 	s, cleanup := newSQLiteTestProvider(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -44,6 +43,9 @@ func TestTokenPoolE2EWithDB(t *testing.T) {
 		Name:       "my-pool",
 		Type:       fftypes.TokenTypeFungible,
 		ProtocolID: "12345",
+		Connector:  "erc1155",
+		Symbol:     "COIN",
+		Message:    fftypes.NewUUID(),
 		TX: fftypes.TransactionRef{
 			Type: fftypes.TransactionTypeTokenPool,
 			ID:   fftypes.NewUUID(),
@@ -51,7 +53,10 @@ func TestTokenPoolE2EWithDB(t *testing.T) {
 	}
 	poolJson, _ := json.Marshal(&pool)
 
-	s.callbacks.On("UUIDCollectionNSEvent", database.CollectionTokenPools, fftypes.ChangeEventTypeCreated, "ns1", poolID, mock.Anything).Return()
+	s.callbacks.On("UUIDCollectionNSEvent", database.CollectionTokenPools, fftypes.ChangeEventTypeCreated, "ns1", poolID, mock.Anything).
+		Return().Once()
+	s.callbacks.On("UUIDCollectionNSEvent", database.CollectionTokenPools, fftypes.ChangeEventTypeUpdated, "ns1", poolID, mock.Anything).
+		Return().Once()
 
 	err := s.UpsertTokenPool(ctx, pool)
 	assert.NoError(t, err)
@@ -84,12 +89,27 @@ func TestTokenPoolE2EWithDB(t *testing.T) {
 		fb.Eq("namespace", pool.Namespace),
 		fb.Eq("name", pool.Name),
 		fb.Eq("protocolid", pool.ProtocolID),
+		fb.Eq("message", pool.Message),
 	)
 	pools, res, err := s.GetTokenPools(ctx, filter.Count(true))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(pools))
 	assert.Equal(t, int64(1), *res.TotalCount)
 	poolReadJson, _ = json.Marshal(pools[0])
+	assert.Equal(t, string(poolJson), string(poolReadJson))
+
+	// Update the token pool
+	pool.ProtocolID = "67890"
+	pool.Type = fftypes.TokenTypeNonFungible
+	err = s.UpsertTokenPool(ctx, pool)
+	assert.NoError(t, err)
+
+	// Query back the token pool (by ID)
+	poolRead, err = s.GetTokenPoolByID(ctx, pool.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, poolRead)
+	poolJson, _ = json.Marshal(&pool)
+	poolReadJson, _ = json.Marshal(&poolRead)
 	assert.Equal(t, string(poolJson), string(poolReadJson))
 }
 
@@ -141,53 +161,6 @@ func TestUpsertTokenPoolFailCommit(t *testing.T) {
 	err := s.UpsertTokenPool(context.Background(), &fftypes.TokenPool{})
 	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestUpsertTokenPoolInsertSuccess(t *testing.T) {
-	s, db := newMockProvider().init()
-	callbacks := &databasemocks.Callbacks{}
-	s.SQLCommon.callbacks = callbacks
-	poolID := fftypes.NewUUID()
-	pool := &fftypes.TokenPool{
-		ID:        poolID,
-		Namespace: "ns1",
-		Type:      fftypes.TokenTypeNonFungible,
-		TX: fftypes.TransactionRef{
-			Type: fftypes.TransactionTypeTokenPool,
-			ID:   fftypes.NewUUID(),
-		},
-	}
-
-	db.ExpectBegin()
-	db.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}))
-	db.ExpectExec("INSERT .*").
-		WithArgs(poolID, "ns1", "", "", "nonfungible", pool.TX.Type, pool.TX.ID).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	db.ExpectCommit()
-	callbacks.On("UUIDCollectionNSEvent", database.CollectionTokenPools, fftypes.ChangeEventTypeCreated, "ns1", poolID, mock.Anything).Return()
-	err := s.UpsertTokenPool(context.Background(), pool)
-	assert.NoError(t, err)
-	assert.NoError(t, db.ExpectationsWereMet())
-}
-
-func TestUpsertTokenPoolUpdateSuccess(t *testing.T) {
-	s, db := newMockProvider().init()
-	callbacks := &databasemocks.Callbacks{}
-	s.SQLCommon.callbacks = callbacks
-	poolID := fftypes.NewUUID()
-	pool := &fftypes.TokenPool{
-		ID:        poolID,
-		Namespace: "ns1",
-	}
-
-	db.ExpectBegin()
-	db.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(poolID))
-	db.ExpectExec("UPDATE .*").WillReturnResult(sqlmock.NewResult(1, 1))
-	db.ExpectCommit()
-	callbacks.On("UUIDCollectionNSEvent", database.CollectionTokenPools, fftypes.ChangeEventTypeUpdated, "ns1", poolID, mock.Anything).Return()
-	err := s.UpsertTokenPool(context.Background(), pool)
-	assert.NoError(t, err)
-	assert.NoError(t, db.ExpectationsWereMet())
 }
 
 func TestUpsertTokenPoolUpdateIDMismatch(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -332,7 +332,7 @@ func (or *orchestrator) initPlugins(ctx context.Context) (err error) {
 			log.L(ctx).Infof("Loading tokens plugin name=%s connector=%s", name, connector)
 			plugin, err := tifactory.GetPlugin(ctx, connector)
 			if plugin != nil {
-				err = plugin.Init(ctx, prefix, &or.bc)
+				err = plugin.Init(ctx, name, prefix, &or.bc)
 			}
 			if err != nil {
 				return err

--- a/internal/tokens/https/https.go
+++ b/internal/tokens/https/https.go
@@ -31,11 +31,12 @@ import (
 )
 
 type HTTPS struct {
-	ctx          context.Context
-	capabilities *tokens.Capabilities
-	callbacks    tokens.Callbacks
-	client       *resty.Client
-	wsconn       wsclient.WSClient
+	ctx            context.Context
+	capabilities   *tokens.Capabilities
+	callbacks      tokens.Callbacks
+	configuredName string
+	client         *resty.Client
+	wsconn         wsclient.WSClient
 }
 
 type wsEvent struct {
@@ -68,10 +69,11 @@ func (h *HTTPS) Name() string {
 	return "https"
 }
 
-func (h *HTTPS) Init(ctx context.Context, prefix config.Prefix, callbacks tokens.Callbacks) (err error) {
+func (h *HTTPS) Init(ctx context.Context, name string, prefix config.Prefix, callbacks tokens.Callbacks) (err error) {
 
 	h.ctx = log.WithLogField(ctx, "proto", "https")
 	h.callbacks = callbacks
+	h.configuredName = name
 
 	if prefix.GetString(restclient.HTTPConfigURL) == "" {
 		return i18n.NewError(ctx, i18n.MsgMissingPluginConfig, "url", "tokens.https")
@@ -159,6 +161,7 @@ func (h *HTTPS) handleTokenPoolCreate(ctx context.Context, data fftypes.JSONObje
 		Namespace:  unpackedData.Namespace,
 		Name:       unpackedData.Name,
 		Type:       fftypes.FFEnum(tokenType),
+		Connector:  h.configuredName,
 		ProtocolID: protocolID,
 	}
 

--- a/internal/tokens/https/https_test.go
+++ b/internal/tokens/https/https_test.go
@@ -60,9 +60,10 @@ func newTestHTTPS(t *testing.T) (h *HTTPS, toServer, fromServer chan string, htt
 	utConfPrefix.AddKnownKey(restclient.HTTPCustomClient, mockedClient)
 	config.Set("tokens", []fftypes.JSONObject{{}})
 
-	err := h.Init(context.Background(), utConfPrefix.ArrayEntry(0), &tokenmocks.Callbacks{})
+	err := h.Init(context.Background(), "testtokens", utConfPrefix.ArrayEntry(0), &tokenmocks.Callbacks{})
 	assert.NoError(t, err)
 	assert.Equal(t, "https", h.Name())
+	assert.Equal(t, "testtokens", h.configuredName)
 	assert.NotNil(t, h.Capabilities())
 	return h, toServer, fromServer, httpURL, func() {
 		cancel()
@@ -78,7 +79,7 @@ func TestInitBadURL(t *testing.T) {
 	utConfPrefix.AddKnownKey(tokens.TokensConfigName, "test")
 	utConfPrefix.AddKnownKey(tokens.TokensConfigConnector, "https")
 	utConfPrefix.AddKnownKey(restclient.HTTPConfigURL, "::::////")
-	err := h.Init(context.Background(), utConfPrefix.ArrayEntry(0), &tokenmocks.Callbacks{})
+	err := h.Init(context.Background(), "testtokens", utConfPrefix.ArrayEntry(0), &tokenmocks.Callbacks{})
 	assert.Regexp(t, "FF10162", err)
 }
 
@@ -90,7 +91,7 @@ func TestInitMissingURL(t *testing.T) {
 	utConfPrefix.AddKnownKey(tokens.TokensConfigName, "test")
 	utConfPrefix.AddKnownKey(tokens.TokensConfigConnector, "https")
 	utConfPrefix.AddKnownKey(restclient.HTTPConfigURL, "")
-	err := h.Init(context.Background(), utConfPrefix.ArrayEntry(0), &tokenmocks.Callbacks{})
+	err := h.Init(context.Background(), "testtokens", utConfPrefix.ArrayEntry(0), &tokenmocks.Callbacks{})
 	assert.Regexp(t, "FF10138", err)
 }
 

--- a/mocks/tokenmocks/plugin.go
+++ b/mocks/tokenmocks/plugin.go
@@ -49,13 +49,13 @@ func (_m *Plugin) CreateTokenPool(ctx context.Context, identity *fftypes.Identit
 	return r0
 }
 
-// Init provides a mock function with given fields: ctx, prefix, callbacks
-func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks tokens.Callbacks) error {
-	ret := _m.Called(ctx, prefix, callbacks)
+// Init provides a mock function with given fields: ctx, name, prefix, callbacks
+func (_m *Plugin) Init(ctx context.Context, name string, prefix config.Prefix, callbacks tokens.Callbacks) error {
+	ret := _m.Called(ctx, name, prefix, callbacks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, config.Prefix, tokens.Callbacks) error); ok {
-		r0 = rf(ctx, prefix, callbacks)
+	if rf, ok := ret.Get(0).(func(context.Context, string, config.Prefix, tokens.Callbacks) error); ok {
+		r0 = rf(ctx, name, prefix, callbacks)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -747,6 +747,8 @@ var TokenPoolQueryFactory = &queryFields{
 	"namespace":  &StringField{},
 	"name":       &StringField{},
 	"protocolid": &StringField{},
+	"symbol":     &StringField{},
+	"message":    &UUIDField{},
 }
 
 // TokenAccountQueryFactory filter fields for token accounts

--- a/pkg/fftypes/tokenpool.go
+++ b/pkg/fftypes/tokenpool.go
@@ -30,5 +30,8 @@ type TokenPool struct {
 	Name       string         `json:"name,omitempty"`
 	ProtocolID string         `json:"protocolId,omitempty"`
 	Author     string         `json:"author,omitempty"`
+	Symbol     string         `json:"symbol,omitempty"`
+	Connector  string         `json:"connector,omitempty"`
+	Message    *UUID          `json:"message,omitempty"`
 	TX         TransactionRef `json:"tx,omitempty"`
 }

--- a/pkg/tokens/plugin.go
+++ b/pkg/tokens/plugin.go
@@ -32,7 +32,7 @@ type Plugin interface {
 
 	// Init initializes the plugin, with configuration
 	// Returns the supported featureset of the interface
-	Init(ctx context.Context, prefix config.Prefix, callbacks Callbacks) error
+	Init(ctx context.Context, name string, prefix config.Prefix, callbacks Callbacks) error
 
 	// Blockchain interface must not deliver any events until start is called
 	Start() error


### PR DESCRIPTION
All token pools should record the connector that created them, may optionally
include a token symbol, and may (in the near future) be linked to a message.